### PR TITLE
Pin orchestrator image and add Copilot preflight

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,5 +1,9 @@
 name: AI Orchestrator
 
+env:
+  ORCHESTRATOR_IMAGE: ghcr.io/purna88836/git-native-agentic-ai-orchestrator@sha256:862e33b924c53110c1b06e406159423dda9ec646ae87f1463b1b9edd0cdbcb92
+  REQUIRED_COPILOT_COMMAND: copilot
+
 on:
   issues:
     types: [opened, edited, reopened]
@@ -37,7 +41,31 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Pull orchestrator image
-        run: docker pull ghcr.io/purna88836/git-native-agentic-ai-orchestrator:latest
+        run: docker pull "$ORCHESTRATOR_IMAGE"
+
+      - name: Preflight Copilot availability
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Preflighting pinned orchestrator image: $ORCHESTRATOR_IMAGE"
+
+          set +e
+          docker run --rm \
+            -e REQUIRED_COPILOT_COMMAND="$REQUIRED_COPILOT_COMMAND" \
+            "$ORCHESTRATOR_IMAGE" \
+            sh -lc 'command -v "$REQUIRED_COPILOT_COMMAND" >/dev/null && "$REQUIRED_COPILOT_COMMAND" --version >/dev/null'
+          status=$?
+          set -e
+
+          if [ "$status" -eq 127 ]; then
+            echo "::error::Pinned orchestrator image $ORCHESTRATOR_IMAGE is missing required command: $REQUIRED_COPILOT_COMMAND"
+            exit 1
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Pinned orchestrator image $ORCHESTRATOR_IMAGE could not invoke required command: $REQUIRED_COPILOT_COMMAND"
+            exit "$status"
+          fi
 
       - name: Run AI Orchestrator
         run: |
@@ -52,4 +80,4 @@ jobs:
             -v "${{ github.workspace }}:/github/workspace" \
             -v "${{ github.event_path }}:/github/workflow/event.json:ro" \
             -w /github/workspace \
-            ghcr.io/purna88836/git-native-agentic-ai-orchestrator:latest
+            "$ORCHESTRATOR_IMAGE"

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -53,7 +53,7 @@ jobs:
           docker run --rm \
             -e REQUIRED_COPILOT_COMMAND="$REQUIRED_COPILOT_COMMAND" \
             "$ORCHESTRATOR_IMAGE" \
-            sh -lc 'command -v "$REQUIRED_COPILOT_COMMAND" >/dev/null && "$REQUIRED_COPILOT_COMMAND" --version >/dev/null'
+            sh -lc 'command -v "$REQUIRED_COPILOT_COMMAND" >/dev/null || exit 127; "$REQUIRED_COPILOT_COMMAND" --version >/dev/null'
           status=$?
           set -e
 


### PR DESCRIPTION
## Summary
- pin the orchestrator container to `ghcr.io/purna88836/git-native-agentic-ai-orchestrator@sha256:862e33b924c53110c1b06e406159423dda9ec646ae87f1463b1b9edd0cdbcb92`
- reuse that single pinned reference in both `docker pull` and `docker run`
- add a preflight step that fails fast when the pinned image cannot provide the required `copilot` command

## Testing
- workflow change only

Closes #7