### PR TITLE
Pin orchestrator image and add Copilot preflight

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -28,7 +28,7 @@ jobs:
   orchestrate:
     runs-on: ubuntu-latest
     env:
-      ORCHESTRATOR_IMAGE: ghcr.io/purna88836/git-native-agentic-ai-orchestrator:0.1.12
+      ORCHESTRATOR_IMAGE: ghcr.io/purna88836/git-native-agentic-ai-orchestrator@sha256:862e33b924c53110c1b06e406159423dda9ec646ae87f1463b1b9edd0cdbcb92
     if: >-
       github.event_name != 'issue_comment' ||
       contains(github.event.comment.body, '@orchestrator')

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   orchestrate:
     runs-on: ubuntu-latest
+    env:
+      ORCHESTRATOR_IMAGE: ghcr.io/purna88836/git-native-agentic-ai-orchestrator:0.1.12
     if: >-
       github.event_name != 'issue_comment' ||
       contains(github.event.comment.body, '@orchestrator')
@@ -37,7 +39,21 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Pull orchestrator image
-        run: docker pull ghcr.io/purna88836/git-native-agentic-ai-orchestrator:latest
+        run: docker pull "$ORCHESTRATOR_IMAGE"
+
+      - name: Preflight Copilot CLI
+        run: |
+          set -euo pipefail
+          preflight_output="$(mktemp)"
+          if docker run --rm --entrypoint copilot "$ORCHESTRATOR_IMAGE" --version >"$preflight_output" 2>&1; then
+            cat "$preflight_output"
+          else
+            diagnostic="$(tr '\n' ' ' <"$preflight_output" | sed 's/  */ /g')"
+            echo "::error title=Copilot CLI missing from pinned orchestrator image::Pinned orchestrator image $ORCHESTRATOR_IMAGE failed preflight command 'copilot --version'. Diagnostic: ${diagnostic:-command produced no output}. Publish or select an image version that includes the Copilot CLI before rerunning this workflow."
+            rm -f "$preflight_output"
+            exit 1
+          fi
+          rm -f "$preflight_output"
 
       - name: Run AI Orchestrator
         run: |
@@ -52,4 +68,4 @@ jobs:
             -v "${{ github.workspace }}:/github/workspace" \
             -v "${{ github.event_path }}:/github/workflow/event.json:ro" \
             -w /github/workspace \
-            ghcr.io/purna88836/git-native-agentic-ai-orchestrator:latest
+            "$ORCHESTRATOR_IMAGE"

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,20 +23,53 @@ Edit `.orchestrator/config.yaml`:
 - Add your GitHub usernames to `human_developers`.
 - Set `auto_merge: true` if you want auto-merging (default: false).
 
-### 3. Update the workflow
+### 3. Pin the workflow image
 
-In `.github/workflows/orchestrator.yml`, replace `YOUR-ORG` with the actual organization name:
+In `.github/workflows/orchestrator.yml`, define a single immutable image reference instead of a mutable tag such as `:latest`:
 
 ```yaml
-uses: docker://ghcr.io/YOUR-ORG/ai-orchestrator:latest
+env:
+  ORCHESTRATOR_IMAGE: ghcr.io/purna88836/git-native-agentic-ai-orchestrator@sha256:862e33b924c53110c1b06e406159423dda9ec646ae87f1463b1b9edd0cdbcb92
 ```
+
+Pinning the orchestrator image to a digest keeps every workflow run traceable to one published container build, makes upgrades reviewable, and prevents a registry tag move from silently changing orchestrator behavior.
+
+Keep that same `ORCHESTRATOR_IMAGE` value wired into all image-consuming steps:
+
+1. `Pull orchestrator image` runs `docker pull "$ORCHESTRATOR_IMAGE"`.
+2. `Preflight Copilot CLI` runs `docker run --rm --entrypoint copilot "$ORCHESTRATOR_IMAGE" --version`.
+3. `Run AI Orchestrator` uses the final `"$ORCHESTRATOR_IMAGE"` argument for the real orchestration run.
+
+If your repository still references a mutable tag directly, migrate it to this shared env-based format before relying on the setup below.
+
+#### Upgrading the pinned image
+
+When maintainers intentionally upgrade the orchestrator image:
+
+1. Get the new published digest for `ghcr.io/purna88836/git-native-agentic-ai-orchestrator`.
+2. Update `jobs.orchestrate.env.ORCHESTRATOR_IMAGE` in `.github/workflows/orchestrator.yml`.
+3. In review, confirm `Pull orchestrator image`, `Preflight Copilot CLI`, and `Run AI Orchestrator` still all use `"$ORCHESTRATOR_IMAGE"`, and that the preflight command is still `copilot --version`.
+4. After the change lands, verify the next workflow run pulls and runs the expected digest.
+
+#### Diagnosing preflight failures
+
+`Preflight Copilot CLI` runs before `Run AI Orchestrator`. If it fails, treat that as a pinned-image problem rather than an issue-payload problem.
+
+The workflow emits an error titled `Copilot CLI missing from pinned orchestrator image` and includes both the pinned image reference and the failed preflight command `copilot --version`.
+
+When that happens:
+
+1. Confirm `ORCHESTRATOR_IMAGE` points to the intended digest.
+2. Read the `Preflight Copilot CLI` step output to capture the emitted diagnostic.
+3. Compare that digest with the image release notes or container contents.
+4. Reproduce locally with `docker run --rm --entrypoint copilot "$ORCHESTRATOR_IMAGE" --version` before changing the workflow again.
 
 ### 4. Grant access (if private image)
 
 If the Docker image is in a private GHCR package:
 
 **Option A — Grant repo access to the package:**
-1. Go to `github.com/orgs/YOUR-ORG/packages/container/ai-orchestrator/settings`
+1. Go to `github.com/orgs/YOUR-ORG/packages/container/git-native-agentic-ai-orchestrator/settings`
 2. Under "Manage Actions access", add your repository
 
 **Option B — Use a PAT:**


### PR DESCRIPTION
## Summary
- pin the orchestrator workflow to `ghcr.io/purna88836/git-native-agentic-ai-orchestrator@sha256:862e33b924c53110c1b06e406159423dda9ec646ae87f1463b1b9edd0cdbcb92` via a single `ORCHESTRATOR_IMAGE` env reference
- use that same immutable reference for both `docker pull` and `docker run`
- keep the preflight `copilot --version` container check that fails fast with an explicit diagnostic naming the pinned image
- update `SETUP.md` so the operator guide matches the same digest format, workflow step names, upgrade process, and preflight diagnostics

## Notes
- the digest is immutable, so every workflow run is traceable to a single published container image
- the docs work from #8 was retargeted onto this implementation branch so the guide lands with the workflow it describes
- addresses sub-issues #7 and #8
