### PR TITLE
Add Todo demo frontend UI

### DIFF
--- a/demo/todo-app/public/app.js
+++ b/demo/todo-app/public/app.js
@@ -1,39 +1,11 @@
-(function () {
-  const state = {
-    todos: [],
-    loading: false,
-    error: "",
-    status: "",
-    editingId: null,
-    pendingIds: new Set(),
-    creating: false,
-  };
-
-  const elements = {
-    createForm: document.querySelector("#create-form"),
-    createButton: document.querySelector("#create-button"),
-    newTodoTitle: document.querySelector("#new-todo-title"),
-    errorBanner: document.querySelector("#error-banner"),
-    statusBanner: document.querySelector("#status-banner"),
-    loadingState: document.querySelector("#loading-state"),
-    emptyState: document.querySelector("#empty-state"),
-    todoList: document.querySelector("#todo-list"),
-    itemTemplate: document.querySelector("#todo-item-template"),
-  };
-
-  function setError(message) {
-    state.error = message;
-    render();
-  }
-
-  function setStatus(message) {
-    state.status = message;
-    render();
-  }
-
-  function clearMessages() {
-    state.error = "";
-    state.status = "";
+(function (globalScope) {
+  function setHeaders(options) {
+    return {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      ...options,
+    };
   }
 
   async function parseJson(response) {
@@ -51,12 +23,11 @@
   }
 
   async function request(path, options) {
-    const response = await fetch(path, {
-      headers: {
-        "Content-Type": "application/json",
-      },
-      ...options,
-    });
+    if (typeof globalScope.fetch !== "function") {
+      throw new Error("Fetch is not available in this environment.");
+    }
+
+    const response = await globalScope.fetch(path, setHeaders(options));
     const data = await parseJson(response);
 
     if (!response.ok) {
@@ -86,217 +57,353 @@
     return value.trim();
   }
 
-  async function loadTodos() {
-    state.loading = true;
-    state.error = "";
-    render();
-
-    try {
-      const payload = await request("/api/todos", { method: "GET" });
-      state.todos = normalizeTodoList(payload);
-    } catch (error) {
-      state.todos = [];
-      setError(error.message);
-    } finally {
-      state.loading = false;
-      render();
+  function createTodoApp(options) {
+    if (!options || typeof options.request !== "function") {
+      throw new Error("A request function is required.");
     }
-  }
 
-  async function createTodo(title) {
-    state.creating = true;
-    clearMessages();
-    render();
+    const state = {
+      todos: [],
+      loading: false,
+      error: "",
+      status: "",
+      editingId: null,
+      pendingIds: new Set(),
+      creating: false,
+    };
+    const onStateChange =
+      typeof options.onStateChange === "function" ? options.onStateChange : function () {};
 
-    try {
-      await request("/api/todos", {
-        method: "POST",
-        body: JSON.stringify({ title }),
-      });
-
-      elements.createForm.reset();
-      await loadTodos();
-      setStatus("Todo created.");
-    } catch (error) {
-      setError(error.message);
-    } finally {
-      state.creating = false;
-      render();
+    function notify() {
+      onStateChange(state);
     }
-  }
 
-  async function updateTodo(id, updates, successMessage) {
-    state.pendingIds.add(id);
-    clearMessages();
-    render();
-
-    try {
-      await request("/api/todos/" + encodeURIComponent(id), {
-        method: "PATCH",
-        body: JSON.stringify(updates),
-      });
-
-      state.editingId = null;
-      await loadTodos();
-      setStatus(successMessage);
-    } catch (error) {
-      setError(error.message);
-    } finally {
-      state.pendingIds.delete(id);
-      render();
+    function setError(message) {
+      state.error = message;
+      notify();
     }
-  }
 
-  async function deleteTodo(id) {
-    state.pendingIds.add(id);
-    clearMessages();
-    render();
+    function setStatus(message) {
+      state.status = message;
+      notify();
+    }
 
-    try {
-      await request("/api/todos/" + encodeURIComponent(id), {
-        method: "DELETE",
-      });
+    function clearMessages() {
+      state.error = "";
+      state.status = "";
+    }
 
-      if (state.editingId === id) {
-        state.editingId = null;
+    async function loadTodos(config) {
+      const shouldThrow = Boolean(config && config.throwOnError);
+
+      state.loading = true;
+      state.error = "";
+      notify();
+
+      try {
+        const payload = await options.request("/api/todos", { method: "GET" });
+        state.todos = normalizeTodoList(payload);
+        return state.todos;
+      } catch (error) {
+        state.todos = [];
+        setError(error.message);
+
+        if (shouldThrow) {
+          throw error;
+        }
+
+        return null;
+      } finally {
+        state.loading = false;
+        notify();
       }
-
-      await loadTodos();
-      setStatus("Todo deleted.");
-    } catch (error) {
-      setError(error.message);
-    } finally {
-      state.pendingIds.delete(id);
-      render();
     }
-  }
 
-  function setBusy(element, busy) {
-    element.disabled = busy;
-  }
+    async function submitCreate(rawTitle, controls) {
+      const title = normalizeTitle(rawTitle);
 
-  function renderMessages() {
-    elements.errorBanner.hidden = !state.error;
-    elements.errorBanner.textContent = state.error;
-
-    elements.statusBanner.hidden = !state.status;
-    elements.statusBanner.textContent = state.status;
-  }
-
-  function renderTodoItem(todo) {
-    const fragment = elements.itemTemplate.content.cloneNode(true);
-    const item = fragment.querySelector(".todo-item");
-    const checkbox = fragment.querySelector(".todo-complete");
-    const title = fragment.querySelector(".todo-title");
-    const editButton = fragment.querySelector(".todo-edit");
-    const deleteButton = fragment.querySelector(".todo-delete");
-    const editForm = fragment.querySelector(".todo-edit-form");
-    const editInput = fragment.querySelector(".todo-edit-input");
-    const saveButton = fragment.querySelector(".todo-save");
-    const cancelButton = fragment.querySelector(".todo-cancel");
-    const view = fragment.querySelector(".todo-view");
-    const isBusy = state.pendingIds.has(todo.id);
-    const isEditing = state.editingId === todo.id;
-
-    item.dataset.todoId = todo.id;
-    checkbox.checked = Boolean(todo.completed);
-    checkbox.setAttribute("aria-label", "Mark " + todo.title + " complete");
-    title.textContent = todo.title;
-    title.classList.toggle("is-completed", Boolean(todo.completed));
-
-    setBusy(checkbox, isBusy);
-    setBusy(editButton, isBusy);
-    setBusy(deleteButton, isBusy);
-    setBusy(editInput, isBusy);
-    setBusy(saveButton, isBusy);
-    setBusy(cancelButton, isBusy);
-
-    view.hidden = isEditing;
-    editForm.hidden = !isEditing;
-    editInput.value = todo.title;
-
-    checkbox.addEventListener("change", function () {
-      updateTodo(todo.id, { completed: checkbox.checked }, "Todo updated.");
-    });
-
-    editButton.addEventListener("click", function () {
-      state.editingId = todo.id;
-      clearMessages();
-      render();
-      const nextItem = Array.from(elements.todoList.children).find(function (node) {
-        return node.dataset.todoId === todo.id;
-      });
-      const nextInput = nextItem ? nextItem.querySelector(".todo-edit-input") : null;
-
-      if (nextInput) {
-        nextInput.focus();
-        nextInput.select();
-      }
-    });
-
-    deleteButton.addEventListener("click", function () {
-      deleteTodo(todo.id);
-    });
-
-    cancelButton.addEventListener("click", function () {
-      state.editingId = null;
-      clearMessages();
-      render();
-    });
-
-    editForm.addEventListener("submit", function (event) {
-      event.preventDefault();
-
-      const nextTitle = normalizeTitle(editInput.value);
-
-      if (!nextTitle) {
+      if (!title) {
         setError("Todo title is required.");
-        editInput.focus();
-        return;
+
+        if (controls && typeof controls.focusInvalid === "function") {
+          controls.focusInvalid();
+        }
+
+        return false;
       }
 
-      updateTodo(todo.id, { title: nextTitle }, "Todo updated.");
+      state.creating = true;
+      clearMessages();
+      notify();
+
+      try {
+        await options.request("/api/todos", {
+          method: "POST",
+          body: JSON.stringify({ title }),
+        });
+
+        if (controls && typeof controls.resetForm === "function") {
+          controls.resetForm();
+        }
+
+        await loadTodos({ throwOnError: true });
+        setStatus("Todo created.");
+        return true;
+      } catch (error) {
+        setError(error.message);
+        return false;
+      } finally {
+        state.creating = false;
+        notify();
+      }
+    }
+
+    async function updateTodo(id, updates, successMessage) {
+      state.pendingIds.add(id);
+      clearMessages();
+      notify();
+
+      try {
+        await options.request("/api/todos/" + encodeURIComponent(id), {
+          method: "PATCH",
+          body: JSON.stringify(updates),
+        });
+
+        state.editingId = null;
+        await loadTodos({ throwOnError: true });
+        setStatus(successMessage);
+        return true;
+      } catch (error) {
+        setError(error.message);
+        return false;
+      } finally {
+        state.pendingIds.delete(id);
+        notify();
+      }
+    }
+
+    async function submitUpdateTitle(id, rawTitle, controls) {
+      const title = normalizeTitle(rawTitle);
+
+      if (!title) {
+        setError("Todo title is required.");
+
+        if (controls && typeof controls.focusInvalid === "function") {
+          controls.focusInvalid();
+        }
+
+        return false;
+      }
+
+      return updateTodo(id, { title: title }, "Todo updated.");
+    }
+
+    async function toggleTodo(id, completed) {
+      return updateTodo(id, { completed: completed }, "Todo updated.");
+    }
+
+    async function deleteTodo(id) {
+      state.pendingIds.add(id);
+      clearMessages();
+      notify();
+
+      try {
+        await options.request("/api/todos/" + encodeURIComponent(id), {
+          method: "DELETE",
+        });
+
+        if (state.editingId === id) {
+          state.editingId = null;
+        }
+
+        await loadTodos({ throwOnError: true });
+        setStatus("Todo deleted.");
+        return true;
+      } catch (error) {
+        setError(error.message);
+        return false;
+      } finally {
+        state.pendingIds.delete(id);
+        notify();
+      }
+    }
+
+    function startEditing(id) {
+      state.editingId = id;
+      clearMessages();
+      notify();
+    }
+
+    function cancelEditing() {
+      state.editingId = null;
+      clearMessages();
+      notify();
+    }
+
+    return {
+      state: state,
+      loadTodos: loadTodos,
+      submitCreate: submitCreate,
+      submitUpdateTitle: submitUpdateTitle,
+      toggleTodo: toggleTodo,
+      deleteTodo: deleteTodo,
+      startEditing: startEditing,
+      cancelEditing: cancelEditing,
+    };
+  }
+
+  function initializeTodoApp(rootDocument) {
+    const elements = {
+      createForm: rootDocument.querySelector("#create-form"),
+      createButton: rootDocument.querySelector("#create-button"),
+      newTodoTitle: rootDocument.querySelector("#new-todo-title"),
+      errorBanner: rootDocument.querySelector("#error-banner"),
+      statusBanner: rootDocument.querySelector("#status-banner"),
+      loadingState: rootDocument.querySelector("#loading-state"),
+      emptyState: rootDocument.querySelector("#empty-state"),
+      todoList: rootDocument.querySelector("#todo-list"),
+      itemTemplate: rootDocument.querySelector("#todo-item-template"),
+    };
+
+    function setBusy(element, busy) {
+      element.disabled = busy;
+    }
+
+    const app = createTodoApp({
+      request: request,
+      onStateChange: render,
     });
 
-    return fragment;
-  }
+    function renderMessages() {
+      elements.errorBanner.hidden = !app.state.error;
+      elements.errorBanner.textContent = app.state.error;
 
-  function renderTodos() {
-    elements.todoList.innerHTML = "";
-
-    for (const todo of state.todos) {
-      elements.todoList.appendChild(renderTodoItem(todo));
-    }
-  }
-
-  function render() {
-    const isBusy = state.loading || state.creating;
-
-    renderMessages();
-    elements.loadingState.hidden = !state.loading;
-    elements.emptyState.hidden = state.loading || state.todos.length > 0 || Boolean(state.error);
-    elements.todoList.hidden = state.loading || state.todos.length === 0;
-    elements.todoList.closest("section").setAttribute("aria-busy", String(state.loading));
-
-    setBusy(elements.newTodoTitle, state.creating);
-    setBusy(elements.createButton, isBusy);
-
-    renderTodos();
-  }
-
-  elements.createForm.addEventListener("submit", function (event) {
-    event.preventDefault();
-
-    const title = normalizeTitle(elements.newTodoTitle.value);
-
-    if (!title) {
-      setError("Todo title is required.");
-      elements.newTodoTitle.focus();
-      return;
+      elements.statusBanner.hidden = !app.state.status;
+      elements.statusBanner.textContent = app.state.status;
     }
 
-    createTodo(title);
-  });
+    function renderTodoItem(todo) {
+      const fragment = elements.itemTemplate.content.cloneNode(true);
+      const item = fragment.querySelector(".todo-item");
+      const checkbox = fragment.querySelector(".todo-complete");
+      const title = fragment.querySelector(".todo-title");
+      const editButton = fragment.querySelector(".todo-edit");
+      const deleteButton = fragment.querySelector(".todo-delete");
+      const editForm = fragment.querySelector(".todo-edit-form");
+      const editInput = fragment.querySelector(".todo-edit-input");
+      const saveButton = fragment.querySelector(".todo-save");
+      const cancelButton = fragment.querySelector(".todo-cancel");
+      const view = fragment.querySelector(".todo-view");
+      const isBusy = app.state.pendingIds.has(todo.id);
+      const isEditing = app.state.editingId === todo.id;
 
-  loadTodos();
-})();
+      item.dataset.todoId = todo.id;
+      checkbox.checked = Boolean(todo.completed);
+      checkbox.setAttribute("aria-label", "Mark " + todo.title + " complete");
+      title.textContent = todo.title;
+      title.classList.toggle("is-completed", Boolean(todo.completed));
+
+      setBusy(checkbox, isBusy);
+      setBusy(editButton, isBusy);
+      setBusy(deleteButton, isBusy);
+      setBusy(editInput, isBusy);
+      setBusy(saveButton, isBusy);
+      setBusy(cancelButton, isBusy);
+
+      view.hidden = isEditing;
+      editForm.hidden = !isEditing;
+      editInput.value = todo.title;
+
+      checkbox.addEventListener("change", function () {
+        app.toggleTodo(todo.id, checkbox.checked);
+      });
+
+      editButton.addEventListener("click", function () {
+        app.startEditing(todo.id);
+        const nextItem = Array.from(elements.todoList.children).find(function (node) {
+          return node.dataset.todoId === todo.id;
+        });
+        const nextInput = nextItem ? nextItem.querySelector(".todo-edit-input") : null;
+
+        if (nextInput) {
+          nextInput.focus();
+          nextInput.select();
+        }
+      });
+
+      deleteButton.addEventListener("click", function () {
+        app.deleteTodo(todo.id);
+      });
+
+      cancelButton.addEventListener("click", function () {
+        app.cancelEditing();
+      });
+
+      editForm.addEventListener("submit", function (event) {
+        event.preventDefault();
+        app.submitUpdateTitle(todo.id, editInput.value, {
+          focusInvalid: function () {
+            editInput.focus();
+          },
+        });
+      });
+
+      return fragment;
+    }
+
+    function renderTodos() {
+      elements.todoList.innerHTML = "";
+
+      for (const todo of app.state.todos) {
+        elements.todoList.appendChild(renderTodoItem(todo));
+      }
+    }
+
+    function render() {
+      const isBusy = app.state.loading || app.state.creating;
+
+      renderMessages();
+      elements.loadingState.hidden = !app.state.loading;
+      elements.emptyState.hidden =
+        app.state.loading || app.state.todos.length > 0 || Boolean(app.state.error);
+      elements.todoList.hidden = app.state.loading || app.state.todos.length === 0;
+      elements.todoList.closest("section").setAttribute("aria-busy", String(app.state.loading));
+
+      setBusy(elements.newTodoTitle, app.state.creating);
+      setBusy(elements.createButton, isBusy);
+
+      renderTodos();
+    }
+
+    elements.createForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+      app.submitCreate(elements.newTodoTitle.value, {
+        resetForm: function () {
+          elements.createForm.reset();
+        },
+        focusInvalid: function () {
+          elements.newTodoTitle.focus();
+        },
+      });
+    });
+
+    app.loadTodos();
+    return app;
+  }
+
+  const exported = {
+    createTodoApp: createTodoApp,
+    initializeTodoApp: initializeTodoApp,
+    normalizeTitle: normalizeTitle,
+    normalizeTodoList: normalizeTodoList,
+    parseJson: parseJson,
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = exported;
+  }
+
+  if (globalScope.document) {
+    initializeTodoApp(globalScope.document);
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this);

--- a/demo/todo-app/public/app.js
+++ b/demo/todo-app/public/app.js
@@ -1,0 +1,302 @@
+(function () {
+  const state = {
+    todos: [],
+    loading: false,
+    error: "",
+    status: "",
+    editingId: null,
+    pendingIds: new Set(),
+    creating: false,
+  };
+
+  const elements = {
+    createForm: document.querySelector("#create-form"),
+    createButton: document.querySelector("#create-button"),
+    newTodoTitle: document.querySelector("#new-todo-title"),
+    errorBanner: document.querySelector("#error-banner"),
+    statusBanner: document.querySelector("#status-banner"),
+    loadingState: document.querySelector("#loading-state"),
+    emptyState: document.querySelector("#empty-state"),
+    todoList: document.querySelector("#todo-list"),
+    itemTemplate: document.querySelector("#todo-item-template"),
+  };
+
+  function setError(message) {
+    state.error = message;
+    render();
+  }
+
+  function setStatus(message) {
+    state.status = message;
+    render();
+  }
+
+  function clearMessages() {
+    state.error = "";
+    state.status = "";
+  }
+
+  async function parseJson(response) {
+    const text = await response.text();
+
+    if (!text) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      throw new Error("The server returned invalid JSON.");
+    }
+  }
+
+  async function request(path, options) {
+    const response = await fetch(path, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      ...options,
+    });
+    const data = await parseJson(response);
+
+    if (!response.ok) {
+      const message =
+        data && typeof data.error === "string"
+          ? data.error
+          : "The request failed. Please try again.";
+      throw new Error(message);
+    }
+
+    return data;
+  }
+
+  function normalizeTodoList(payload) {
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (payload && Array.isArray(payload.todos)) {
+      return payload.todos;
+    }
+
+    throw new Error("The server returned an unexpected todo list shape.");
+  }
+
+  function normalizeTitle(value) {
+    return value.trim();
+  }
+
+  async function loadTodos() {
+    state.loading = true;
+    state.error = "";
+    render();
+
+    try {
+      const payload = await request("/api/todos", { method: "GET" });
+      state.todos = normalizeTodoList(payload);
+    } catch (error) {
+      state.todos = [];
+      setError(error.message);
+    } finally {
+      state.loading = false;
+      render();
+    }
+  }
+
+  async function createTodo(title) {
+    state.creating = true;
+    clearMessages();
+    render();
+
+    try {
+      await request("/api/todos", {
+        method: "POST",
+        body: JSON.stringify({ title }),
+      });
+
+      elements.createForm.reset();
+      await loadTodos();
+      setStatus("Todo created.");
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      state.creating = false;
+      render();
+    }
+  }
+
+  async function updateTodo(id, updates, successMessage) {
+    state.pendingIds.add(id);
+    clearMessages();
+    render();
+
+    try {
+      await request("/api/todos/" + encodeURIComponent(id), {
+        method: "PATCH",
+        body: JSON.stringify(updates),
+      });
+
+      state.editingId = null;
+      await loadTodos();
+      setStatus(successMessage);
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      state.pendingIds.delete(id);
+      render();
+    }
+  }
+
+  async function deleteTodo(id) {
+    state.pendingIds.add(id);
+    clearMessages();
+    render();
+
+    try {
+      await request("/api/todos/" + encodeURIComponent(id), {
+        method: "DELETE",
+      });
+
+      if (state.editingId === id) {
+        state.editingId = null;
+      }
+
+      await loadTodos();
+      setStatus("Todo deleted.");
+    } catch (error) {
+      setError(error.message);
+    } finally {
+      state.pendingIds.delete(id);
+      render();
+    }
+  }
+
+  function setBusy(element, busy) {
+    element.disabled = busy;
+  }
+
+  function renderMessages() {
+    elements.errorBanner.hidden = !state.error;
+    elements.errorBanner.textContent = state.error;
+
+    elements.statusBanner.hidden = !state.status;
+    elements.statusBanner.textContent = state.status;
+  }
+
+  function renderTodoItem(todo) {
+    const fragment = elements.itemTemplate.content.cloneNode(true);
+    const item = fragment.querySelector(".todo-item");
+    const checkbox = fragment.querySelector(".todo-complete");
+    const title = fragment.querySelector(".todo-title");
+    const editButton = fragment.querySelector(".todo-edit");
+    const deleteButton = fragment.querySelector(".todo-delete");
+    const editForm = fragment.querySelector(".todo-edit-form");
+    const editInput = fragment.querySelector(".todo-edit-input");
+    const saveButton = fragment.querySelector(".todo-save");
+    const cancelButton = fragment.querySelector(".todo-cancel");
+    const view = fragment.querySelector(".todo-view");
+    const isBusy = state.pendingIds.has(todo.id);
+    const isEditing = state.editingId === todo.id;
+
+    item.dataset.todoId = todo.id;
+    checkbox.checked = Boolean(todo.completed);
+    checkbox.setAttribute("aria-label", "Mark " + todo.title + " complete");
+    title.textContent = todo.title;
+    title.classList.toggle("is-completed", Boolean(todo.completed));
+
+    setBusy(checkbox, isBusy);
+    setBusy(editButton, isBusy);
+    setBusy(deleteButton, isBusy);
+    setBusy(editInput, isBusy);
+    setBusy(saveButton, isBusy);
+    setBusy(cancelButton, isBusy);
+
+    view.hidden = isEditing;
+    editForm.hidden = !isEditing;
+    editInput.value = todo.title;
+
+    checkbox.addEventListener("change", function () {
+      updateTodo(todo.id, { completed: checkbox.checked }, "Todo updated.");
+    });
+
+    editButton.addEventListener("click", function () {
+      state.editingId = todo.id;
+      clearMessages();
+      render();
+      const nextItem = Array.from(elements.todoList.children).find(function (node) {
+        return node.dataset.todoId === todo.id;
+      });
+      const nextInput = nextItem ? nextItem.querySelector(".todo-edit-input") : null;
+
+      if (nextInput) {
+        nextInput.focus();
+        nextInput.select();
+      }
+    });
+
+    deleteButton.addEventListener("click", function () {
+      deleteTodo(todo.id);
+    });
+
+    cancelButton.addEventListener("click", function () {
+      state.editingId = null;
+      clearMessages();
+      render();
+    });
+
+    editForm.addEventListener("submit", function (event) {
+      event.preventDefault();
+
+      const nextTitle = normalizeTitle(editInput.value);
+
+      if (!nextTitle) {
+        setError("Todo title is required.");
+        editInput.focus();
+        return;
+      }
+
+      updateTodo(todo.id, { title: nextTitle }, "Todo updated.");
+    });
+
+    return fragment;
+  }
+
+  function renderTodos() {
+    elements.todoList.innerHTML = "";
+
+    for (const todo of state.todos) {
+      elements.todoList.appendChild(renderTodoItem(todo));
+    }
+  }
+
+  function render() {
+    const isBusy = state.loading || state.creating;
+
+    renderMessages();
+    elements.loadingState.hidden = !state.loading;
+    elements.emptyState.hidden = state.loading || state.todos.length > 0 || Boolean(state.error);
+    elements.todoList.hidden = state.loading || state.todos.length === 0;
+    elements.todoList.closest("section").setAttribute("aria-busy", String(state.loading));
+
+    setBusy(elements.newTodoTitle, state.creating);
+    setBusy(elements.createButton, isBusy);
+
+    renderTodos();
+  }
+
+  elements.createForm.addEventListener("submit", function (event) {
+    event.preventDefault();
+
+    const title = normalizeTitle(elements.newTodoTitle.value);
+
+    if (!title) {
+      setError("Todo title is required.");
+      elements.newTodoTitle.focus();
+      return;
+    }
+
+    createTodo(title);
+  });
+
+  loadTodos();
+})();

--- a/demo/todo-app/public/index.html
+++ b/demo/todo-app/public/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app-shell">
+      <section class="app-card">
+        <header class="app-header">
+          <div>
+            <p class="eyebrow">Demo</p>
+            <h1>Todo App</h1>
+            <p class="subtitle">A small CRUD UI for the `/api/todos` demo API.</p>
+          </div>
+        </header>
+
+        <div id="error-banner" class="banner banner-error" hidden role="alert"></div>
+        <div id="status-banner" class="banner banner-info" hidden aria-live="polite"></div>
+
+        <form id="create-form" class="create-form">
+          <label class="sr-only" for="new-todo-title">New todo title</label>
+          <input
+            id="new-todo-title"
+            name="title"
+            type="text"
+            maxlength="200"
+            placeholder="What needs to be done?"
+            autocomplete="off"
+            required
+          />
+          <button id="create-button" type="submit">Add todo</button>
+        </form>
+
+        <section aria-live="polite" aria-busy="false">
+          <div id="loading-state" class="panel-state" hidden>Loading todos...</div>
+          <div id="empty-state" class="panel-state" hidden>No todos yet. Add one to get started.</div>
+          <ul id="todo-list" class="todo-list" aria-label="Todo items"></ul>
+        </section>
+      </section>
+    </main>
+
+    <template id="todo-item-template">
+      <li class="todo-item">
+        <div class="todo-view">
+          <label class="todo-toggle">
+            <input class="todo-complete" type="checkbox" />
+            <span class="todo-title"></span>
+          </label>
+          <div class="todo-actions">
+            <button class="button-secondary todo-edit" type="button">Edit</button>
+            <button class="button-danger todo-delete" type="button">Delete</button>
+          </div>
+        </div>
+
+        <form class="todo-edit-form" hidden>
+          <label class="sr-only">Edit todo title</label>
+          <input class="todo-edit-input" type="text" maxlength="200" required />
+          <div class="todo-actions">
+            <button class="todo-save" type="submit">Save</button>
+            <button class="button-secondary todo-cancel" type="button">Cancel</button>
+          </div>
+        </form>
+      </li>
+    </template>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/demo/todo-app/public/styles.css
+++ b/demo/todo-app/public/styles.css
@@ -1,0 +1,218 @@
+:root {
+  color-scheme: light;
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.5;
+  color: #1f2933;
+  background: #f4f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef2f7 100%);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  border-radius: 0.6rem;
+  background: #2563eb;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 0.7rem 1rem;
+  transition: opacity 0.2s ease, background-color 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  background: #1d4ed8;
+}
+
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+input[type="text"] {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.6rem;
+  padding: 0.75rem 0.9rem;
+  background: #ffffff;
+}
+
+.app-shell {
+  padding: 2rem 1rem;
+}
+
+.app-card {
+  max-width: 48rem;
+  margin: 0 auto;
+  background: #ffffff;
+  border: 1px solid #dbe4f0;
+  border-radius: 1rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+}
+
+.app-header {
+  margin-bottom: 1.25rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin: 0.35rem 0 0;
+  color: #52606d;
+}
+
+.banner {
+  border-radius: 0.75rem;
+  padding: 0.85rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.banner-error {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+}
+
+.banner-info {
+  background: #dbeafe;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
+.create-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.panel-state {
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  text-align: center;
+  color: #52606d;
+  background: #f8fafc;
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.todo-item {
+  border: 1px solid #dbe4f0;
+  border-radius: 0.85rem;
+  padding: 1rem;
+  background: #ffffff;
+}
+
+.todo-view,
+.todo-edit-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.todo-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.todo-complete {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #2563eb;
+}
+
+.todo-title {
+  overflow-wrap: anywhere;
+}
+
+.todo-title.is-completed {
+  color: #64748b;
+  text-decoration: line-through;
+}
+
+.todo-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.button-secondary {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.button-secondary:hover:not(:disabled) {
+  background: #cbd5e1;
+}
+
+.button-danger {
+  background: #dc2626;
+}
+
+.button-danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 640px) {
+  .app-card {
+    padding: 1rem;
+  }
+
+  .create-form,
+  .todo-view,
+  .todo-edit-form {
+    grid-template-columns: 1fr;
+  }
+
+  .todo-actions {
+    justify-content: flex-start;
+  }
+}

--- a/demo/todo-app/test/app.test.js
+++ b/demo/todo-app/test/app.test.js
@@ -1,0 +1,241 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { createTodoApp } = require("../public/app.js");
+
+function createRequestQueue(steps) {
+  const calls = [];
+
+  async function request(path, options) {
+    const step = steps.shift();
+
+    if (!step) {
+      throw new Error("Unexpected request for " + path);
+    }
+
+    calls.push({ path, options });
+
+    if (step.path) {
+      assert.equal(path, step.path);
+    }
+
+    if (step.method) {
+      assert.equal(options && options.method, step.method);
+    }
+
+    if (step.body !== undefined) {
+      assert.equal(options && options.body, JSON.stringify(step.body));
+    }
+
+    if (step.error) {
+      throw step.error;
+    }
+
+    return step.result;
+  }
+
+  request.calls = calls;
+  return request;
+}
+
+test("loadTodos surfaces initial load failures", async function () {
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos",
+        method: "GET",
+        error: new Error("Todo list unavailable."),
+      },
+    ]),
+  });
+
+  await assert.rejects(app.loadTodos({ throwOnError: true }), /Todo list unavailable\./);
+
+  assert.deepEqual(app.state.todos, []);
+  assert.equal(app.state.error, "Todo list unavailable.");
+  assert.equal(app.state.status, "");
+  assert.equal(app.state.loading, false);
+});
+
+test("submitCreate rejects empty titles before making a request", async function () {
+  let focused = 0;
+  let requestCalled = false;
+  const app = createTodoApp({
+    request: async function () {
+      requestCalled = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  const result = await app.submitCreate("   ", {
+    focusInvalid: function () {
+      focused += 1;
+    },
+  });
+
+  assert.equal(result, false);
+  assert.equal(requestCalled, false);
+  assert.equal(focused, 1);
+  assert.equal(app.state.error, "Todo title is required.");
+  assert.equal(app.state.status, "");
+  assert.equal(app.state.creating, false);
+});
+
+test("submitUpdateTitle rejects empty edits before making a request", async function () {
+  let focused = 0;
+  let requestCalled = false;
+  const app = createTodoApp({
+    request: async function () {
+      requestCalled = true;
+      throw new Error("should not be called");
+    },
+  });
+
+  const result = await app.submitUpdateTitle("abc", "   ", {
+    focusInvalid: function () {
+      focused += 1;
+    },
+  });
+
+  assert.equal(result, false);
+  assert.equal(requestCalled, false);
+  assert.equal(focused, 1);
+  assert.equal(app.state.error, "Todo title is required.");
+  assert.equal(app.state.status, "");
+});
+
+test("submitCreate shows request failures without a success banner", async function () {
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos",
+        method: "POST",
+        body: { title: "Ship tests" },
+        error: new Error("Create failed."),
+      },
+    ]),
+  });
+
+  const result = await app.submitCreate("Ship tests");
+
+  assert.equal(result, false);
+  assert.equal(app.state.error, "Create failed.");
+  assert.equal(app.state.status, "");
+  assert.equal(app.state.creating, false);
+});
+
+test("submitCreate only shows success after the refresh succeeds", async function () {
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos",
+        method: "POST",
+        body: { title: "Ship tests" },
+        result: { id: "created" },
+      },
+      {
+        path: "/api/todos",
+        method: "GET",
+        error: new Error("Refresh failed."),
+      },
+    ]),
+  });
+  let resetCount = 0;
+
+  const result = await app.submitCreate("Ship tests", {
+    resetForm: function () {
+      resetCount += 1;
+    },
+  });
+
+  assert.equal(result, false);
+  assert.equal(resetCount, 1);
+  assert.equal(app.state.error, "Refresh failed.");
+  assert.equal(app.state.status, "");
+  assert.deepEqual(app.state.todos, []);
+  assert.equal(app.state.creating, false);
+});
+
+test("submitCreate updates the list and status after a successful refresh", async function () {
+  const todo = { id: "1", title: "Ship tests", completed: false };
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos",
+        method: "POST",
+        body: { title: "Ship tests" },
+        result: todo,
+      },
+      {
+        path: "/api/todos",
+        method: "GET",
+        result: [todo],
+      },
+    ]),
+  });
+
+  const result = await app.submitCreate("Ship tests");
+
+  assert.equal(result, true);
+  assert.equal(app.state.error, "");
+  assert.equal(app.state.status, "Todo created.");
+  assert.deepEqual(app.state.todos, [todo]);
+});
+
+test("toggleTodo keeps refresh failures in the error state", async function () {
+  const todo = { id: "abc", title: "Ship tests", completed: false };
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos/abc",
+        method: "PATCH",
+        body: { completed: true },
+        result: { ...todo, completed: true },
+      },
+      {
+        path: "/api/todos",
+        method: "GET",
+        error: new Error("Refresh failed."),
+      },
+    ]),
+  });
+
+  app.state.todos = [todo];
+
+  const result = await app.toggleTodo("abc", true);
+
+  assert.equal(result, false);
+  assert.equal(app.state.error, "Refresh failed.");
+  assert.equal(app.state.status, "");
+  assert.equal(app.state.pendingIds.size, 0);
+});
+
+test("deleteTodo clears editing state after a successful refresh", async function () {
+  const todo = { id: "abc", title: "Ship tests", completed: false };
+  const app = createTodoApp({
+    request: createRequestQueue([
+      {
+        path: "/api/todos/abc",
+        method: "DELETE",
+        result: null,
+      },
+      {
+        path: "/api/todos",
+        method: "GET",
+        result: [],
+      },
+    ]),
+  });
+
+  app.state.todos = [todo];
+  app.state.editingId = "abc";
+
+  const result = await app.deleteTodo("abc");
+
+  assert.equal(result, true);
+  assert.equal(app.state.editingId, null);
+  assert.equal(app.state.error, "");
+  assert.equal(app.state.status, "Todo deleted.");
+  assert.deepEqual(app.state.todos, []);
+  assert.equal(app.state.pendingIds.size, 0);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "gitnative-ai-orchestrator-testing",
+  "private": true,
+  "scripts": {
+    "test": "node --test demo/todo-app/test/app.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add a plain HTML shell for the Todo demo under `demo/todo-app/public/`
- add lightweight CSS for create, list, edit, toggle, delete, and basic state banners
- add browser-side CRUD logic for `/api/todos` with loading, empty, success, and error handling

## Contract assumptions
- primary assumption from #13: `GET /api/todos` returns a JSON array of Todo objects shaped as `{ id, title, completed, createdAt }`
- the UI also tolerates `{ "todos": [...] }` for the list response to stay resilient while backend work on #15 lands
- `POST` and `PATCH` are expected to accept/return JSON
- `DELETE /api/todos/:id` may return an empty body (for example `204 No Content`), which the UI already handles

## Notes
- this PR keeps all frontend work isolated under `demo/todo-app/public/`
- backend/runtime wiring is intentionally left to #15 and follow-up integration work

Closes #17