### PR TITLE
Add Todo demo validation and isolated CI workflow

### DIFF
--- a/.github/workflows/todo-demo.yml
+++ b/.github/workflows/todo-demo.yml
@@ -1,0 +1,32 @@
+name: Todo Demo Validation
+
+on:
+  push:
+    paths:
+      - 'demo/todo-app/**'
+      - '.github/workflows/todo-demo.yml'
+  pull_request:
+    paths:
+      - 'demo/todo-app/**'
+      - '.github/workflows/todo-demo.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: demo/todo-app
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run demo tests with coverage
+        run: npm run test:coverage

--- a/demo/todo-app/package.json
+++ b/demo/todo-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "todo-demo-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test",
+    "test:coverage": "node --test --experimental-test-coverage"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/demo/todo-app/public/index.html
+++ b/demo/todo-app/public/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Todo Demo</title>
+  </head>
+  <body>
+    <main>
+      <h1>Todo Demo Backend</h1>
+      <p>The Todo API is ready. The browser UI lands separately in issue #17.</p>
+    </main>
+  </body>
+</html>

--- a/demo/todo-app/server.js
+++ b/demo/todo-app/server.js
@@ -1,0 +1,97 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { dirname, extname, join, normalize, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createTodoHandler } from './src/todo-routes.js';
+import { TodoStore } from './src/todo-store.js';
+
+const modulePath = fileURLToPath(import.meta.url);
+const moduleDir = dirname(modulePath);
+const defaultDataPath = join(moduleDir, 'data', 'todos.json');
+const defaultPublicDir = join(moduleDir, 'public');
+
+const contentTypes = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8'
+};
+
+function sendPlainText(response, statusCode, message) {
+  response.writeHead(statusCode, {
+    'content-type': 'text/plain; charset=utf-8',
+    'content-length': Buffer.byteLength(message)
+  });
+  response.end(message);
+}
+
+async function serveStaticAsset(request, response, publicDir) {
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    sendPlainText(response, 404, 'Not found');
+    return;
+  }
+
+  const requestUrl = new URL(request.url, 'http://localhost');
+  const assetPath = requestUrl.pathname === '/' ? '/index.html' : requestUrl.pathname;
+  const absolutePublicDir = resolve(publicDir);
+  const filePath = resolve(join(absolutePublicDir, `.${assetPath}`));
+
+  if (!filePath.startsWith(`${normalize(absolutePublicDir)}${sep}`)) {
+    sendPlainText(response, 404, 'Not found');
+    return;
+  }
+
+  try {
+    const fileBuffer = await readFile(filePath);
+
+    response.writeHead(200, {
+      'content-type': contentTypes[extname(filePath)] ?? 'application/octet-stream',
+      'content-length': fileBuffer.byteLength
+    });
+
+    if (request.method === 'HEAD') {
+      response.end();
+      return;
+    }
+
+    response.end(fileBuffer);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      sendPlainText(response, 404, 'Not found');
+      return;
+    }
+
+    console.error('Failed to serve static asset', error);
+    sendPlainText(response, 500, 'Internal server error');
+  }
+}
+
+export function createAppServer({
+  store = new TodoStore({ filePath: defaultDataPath }),
+  publicDir = defaultPublicDir
+} = {}) {
+  const handleTodoRequest = createTodoHandler({ store });
+
+  return createServer(async (request, response) => {
+    try {
+      if (await handleTodoRequest(request, response)) {
+        return;
+      }
+
+      await serveStaticAsset(request, response, publicDir);
+    } catch (error) {
+      console.error('Unexpected server error', error);
+      sendPlainText(response, 500, 'Internal server error');
+    }
+  });
+}
+
+if (process.argv[1] === modulePath) {
+  const port = Number.parseInt(process.env.PORT ?? '3000', 10);
+  const server = createAppServer();
+
+  server.listen(port, () => {
+    console.log(`Todo demo server listening on http://localhost:${port}`);
+  });
+}

--- a/demo/todo-app/src/todo-routes.js
+++ b/demo/todo-app/src/todo-routes.js
@@ -1,0 +1,111 @@
+import { TodoStoreError } from './todo-store.js';
+
+function writeJson(response, statusCode, payload) {
+  const responseBody = JSON.stringify(payload);
+
+  response.writeHead(statusCode, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(responseBody)
+  });
+  response.end(responseBody);
+}
+
+function writeError(response, statusCode, code, message) {
+  writeJson(response, statusCode, {
+    error: {
+      code,
+      message
+    }
+  });
+}
+
+async function readJsonBody(request) {
+  const chunks = [];
+
+  for await (const chunk of request) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8'));
+  } catch (error) {
+    throw new TodoStoreError('Request body must be valid JSON.', {
+      code: 'INVALID_JSON',
+      status: 400,
+      cause: error
+    });
+  }
+}
+
+export function createTodoHandler({ store }) {
+  if (!store) {
+    throw new TypeError('store is required');
+  }
+
+  return async function handleTodoRequest(request, response) {
+    const url = new URL(request.url, 'http://localhost');
+
+    if (!url.pathname.startsWith('/api/todos')) {
+      return false;
+    }
+
+    try {
+      if (url.pathname === '/api/todos') {
+        if (request.method === 'GET') {
+          const todos = await store.list();
+          writeJson(response, 200, { todos });
+          return true;
+        }
+
+        if (request.method === 'POST') {
+          const payload = await readJsonBody(request);
+          const todo = await store.create(payload);
+          writeJson(response, 201, { todo });
+          return true;
+        }
+
+        writeError(response, 405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+        return true;
+      }
+
+      const pathMatch = url.pathname.match(/^\/api\/todos\/([^/]+)$/);
+
+      if (!pathMatch) {
+        writeError(response, 404, 'ROUTE_NOT_FOUND', 'Route not found.');
+        return true;
+      }
+
+      const [, todoId] = pathMatch;
+
+      if (request.method === 'PATCH') {
+        const payload = await readJsonBody(request);
+        const todo = await store.update(todoId, payload);
+        writeJson(response, 200, { todo });
+        return true;
+      }
+
+      if (request.method === 'DELETE') {
+        await store.remove(todoId);
+        response.writeHead(204);
+        response.end();
+        return true;
+      }
+
+      writeError(response, 405, 'METHOD_NOT_ALLOWED', 'Method not allowed.');
+      return true;
+    } catch (error) {
+      if (error instanceof TodoStoreError) {
+        writeError(response, error.status, error.code, error.message);
+        return true;
+      }
+
+      console.error('Todo route error', error);
+      writeError(response, 500, 'INTERNAL_SERVER_ERROR', 'Internal server error.');
+      return true;
+    }
+  };
+}

--- a/demo/todo-app/src/todo-store.js
+++ b/demo/todo-app/src/todo-store.js
@@ -1,0 +1,202 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+export class TodoStoreError extends Error {
+  constructor(message, { code, status = 400, cause } = {}) {
+    super(message, { cause });
+    this.name = 'TodoStoreError';
+    this.code = code ?? 'TODO_STORE_ERROR';
+    this.status = status;
+  }
+}
+
+function validateTitle(title) {
+  return typeof title === 'string' && title.trim().length > 0;
+}
+
+function cloneTodo(todo) {
+  return { ...todo };
+}
+
+export class TodoStore {
+  #writeQueue = Promise.resolve();
+
+  constructor({ filePath }) {
+    if (!filePath) {
+      throw new TypeError('filePath is required');
+    }
+
+    this.filePath = filePath;
+  }
+
+  async list() {
+    const todos = await this.#readTodos();
+    return todos.map(cloneTodo);
+  }
+
+  async create(input) {
+    if (!validateTitle(input?.title)) {
+      throw new TodoStoreError('Title is required.', {
+        code: 'INVALID_TITLE',
+        status: 400
+      });
+    }
+
+    const todo = {
+      id: randomUUID(),
+      title: input.title.trim(),
+      completed: false,
+      createdAt: new Date().toISOString()
+    };
+
+    return this.#mutate(async (todos) => ({
+      todos: [...todos, todo],
+      value: cloneTodo(todo)
+    }));
+  }
+
+  async update(id, updates) {
+    if (!id) {
+      throw new TodoStoreError('Todo id is required.', {
+        code: 'INVALID_ID',
+        status: 400
+      });
+    }
+
+    const hasTitle = Object.hasOwn(updates ?? {}, 'title');
+    const hasCompleted = Object.hasOwn(updates ?? {}, 'completed');
+
+    if (!hasTitle && !hasCompleted) {
+      throw new TodoStoreError('Update payload must include title or completed.', {
+        code: 'INVALID_UPDATE',
+        status: 400
+      });
+    }
+
+    if (hasTitle && !validateTitle(updates.title)) {
+      throw new TodoStoreError('Title must be a non-empty string.', {
+        code: 'INVALID_TITLE',
+        status: 400
+      });
+    }
+
+    if (hasCompleted && typeof updates.completed !== 'boolean') {
+      throw new TodoStoreError('Completed must be a boolean.', {
+        code: 'INVALID_COMPLETED',
+        status: 400
+      });
+    }
+
+    return this.#mutate(async (todos) => {
+      const index = todos.findIndex((todo) => todo.id === id);
+
+      if (index === -1) {
+        throw new TodoStoreError(`Todo ${id} was not found.`, {
+          code: 'TODO_NOT_FOUND',
+          status: 404
+        });
+      }
+
+      const updatedTodo = {
+        ...todos[index],
+        ...(hasTitle ? { title: updates.title.trim() } : {}),
+        ...(hasCompleted ? { completed: updates.completed } : {})
+      };
+
+      const nextTodos = [...todos];
+      nextTodos[index] = updatedTodo;
+
+      return {
+        todos: nextTodos,
+        value: cloneTodo(updatedTodo)
+      };
+    });
+  }
+
+  async remove(id) {
+    if (!id) {
+      throw new TodoStoreError('Todo id is required.', {
+        code: 'INVALID_ID',
+        status: 400
+      });
+    }
+
+    return this.#mutate(async (todos) => {
+      const index = todos.findIndex((todo) => todo.id === id);
+
+      if (index === -1) {
+        throw new TodoStoreError(`Todo ${id} was not found.`, {
+          code: 'TODO_NOT_FOUND',
+          status: 404
+        });
+      }
+
+      const nextTodos = [...todos];
+      const [removedTodo] = nextTodos.splice(index, 1);
+
+      return {
+        todos: nextTodos,
+        value: cloneTodo(removedTodo)
+      };
+    });
+  }
+
+  async #ensureFile() {
+    await mkdir(dirname(this.filePath), { recursive: true });
+
+    try {
+      await readFile(this.filePath, 'utf8');
+    } catch (error) {
+      if (error && error.code === 'ENOENT') {
+        await writeFile(this.filePath, '[]\n', 'utf8');
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  async #readTodos() {
+    await this.#ensureFile();
+
+    try {
+      const fileContents = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(fileContents || '[]');
+
+      if (!Array.isArray(parsed)) {
+        throw new Error('Todo store must contain an array.');
+      }
+
+      return parsed;
+    } catch (error) {
+      if (error instanceof TodoStoreError) {
+        throw error;
+      }
+
+      throw new TodoStoreError('Todo data could not be read.', {
+        code: 'STORE_READ_FAILED',
+        status: 500,
+        cause: error
+      });
+    }
+  }
+
+  async #writeTodos(todos) {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, `${JSON.stringify(todos, null, 2)}\n`, 'utf8');
+  }
+
+  async #mutate(operation) {
+    const nextMutation = this.#writeQueue.catch(() => undefined).then(async () => {
+      const currentTodos = await this.#readTodos();
+      const result = await operation(currentTodos);
+
+      await this.#writeTodos(result.todos);
+      return result.value;
+    });
+
+    this.#writeQueue = nextMutation.catch(() => undefined);
+    return nextMutation;
+  }
+}

--- a/demo/todo-app/test/todo-api.test.js
+++ b/demo/todo-app/test/todo-api.test.js
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { createAppServer } from '../server.js';
+import { TodoStore } from '../src/todo-store.js';
+
+async function createApiHarness() {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'todo-api-'));
+  const store = new TodoStore({
+    filePath: join(tempDirectory, 'todos.json')
+  });
+  const server = createAppServer({
+    store,
+    publicDir: join(tempDirectory, 'public')
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const { port } = server.address();
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  };
+}
+
+async function request(baseUrl, path, options) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const rawBody = await response.text();
+
+  return {
+    response,
+    body: rawBody ? JSON.parse(rawBody) : null
+  };
+}
+
+test('todo API supports create, list, update, and delete flows', async () => {
+  const api = await createApiHarness();
+
+  try {
+    const createResult = await request(api.baseUrl, '/api/todos', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ title: 'Ship the Todo demo' })
+    });
+
+    assert.equal(createResult.response.status, 201);
+    assert.equal(createResult.body.todo.title, 'Ship the Todo demo');
+    assert.equal(createResult.body.todo.completed, false);
+
+    const listAfterCreate = await request(api.baseUrl, '/api/todos');
+    assert.equal(listAfterCreate.response.status, 200);
+    assert.deepEqual(listAfterCreate.body.todos, [createResult.body.todo]);
+
+    const updateResult = await request(api.baseUrl, `/api/todos/${createResult.body.todo.id}`, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        title: 'Ship the tested Todo demo',
+        completed: true
+      })
+    });
+
+    assert.equal(updateResult.response.status, 200);
+    assert.equal(updateResult.body.todo.title, 'Ship the tested Todo demo');
+    assert.equal(updateResult.body.todo.completed, true);
+
+    const deleteResult = await request(api.baseUrl, `/api/todos/${createResult.body.todo.id}`, {
+      method: 'DELETE'
+    });
+    assert.equal(deleteResult.response.status, 204);
+    assert.equal(deleteResult.body, null);
+
+    const finalList = await request(api.baseUrl, '/api/todos');
+    assert.equal(finalList.response.status, 200);
+    assert.deepEqual(finalList.body.todos, []);
+  } finally {
+    await api.close();
+  }
+});
+
+test('todo API returns 400 responses for invalid payloads', async () => {
+  const api = await createApiHarness();
+
+  try {
+    const invalidCreate = await request(api.baseUrl, '/api/todos', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ title: '   ' })
+    });
+
+    assert.equal(invalidCreate.response.status, 400);
+    assert.equal(invalidCreate.body.error.code, 'INVALID_TITLE');
+
+    const createValidTodo = await request(api.baseUrl, '/api/todos', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ title: 'Keep this todo' })
+    });
+
+    const invalidUpdate = await request(api.baseUrl, `/api/todos/${createValidTodo.body.todo.id}`, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({})
+    });
+
+    assert.equal(invalidUpdate.response.status, 400);
+    assert.equal(invalidUpdate.body.error.code, 'INVALID_UPDATE');
+
+    const malformedJson = await request(api.baseUrl, '/api/todos', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: '{"title":'
+    });
+
+    assert.equal(malformedJson.response.status, 400);
+    assert.equal(malformedJson.body.error.code, 'INVALID_JSON');
+  } finally {
+    await api.close();
+  }
+});
+
+test('todo API returns 404 and 405 responses for error cases', async () => {
+  const api = await createApiHarness();
+
+  try {
+    const missingTodoUpdate = await request(api.baseUrl, '/api/todos/missing-id', {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ completed: true })
+    });
+
+    assert.equal(missingTodoUpdate.response.status, 404);
+    assert.equal(missingTodoUpdate.body.error.code, 'TODO_NOT_FOUND');
+
+    const missingTodoDelete = await request(api.baseUrl, '/api/todos/missing-id', {
+      method: 'DELETE'
+    });
+
+    assert.equal(missingTodoDelete.response.status, 404);
+    assert.equal(missingTodoDelete.body.error.code, 'TODO_NOT_FOUND');
+
+    const wrongMethod = await request(api.baseUrl, '/api/todos/missing-id', {
+      method: 'GET'
+    });
+
+    assert.equal(wrongMethod.response.status, 405);
+    assert.equal(wrongMethod.body.error.code, 'METHOD_NOT_ALLOWED');
+
+    const unknownRoute = await request(api.baseUrl, '/api/todos/missing-id/extra');
+    assert.equal(unknownRoute.response.status, 404);
+    assert.equal(unknownRoute.body.error.code, 'ROUTE_NOT_FOUND');
+  } finally {
+    await api.close();
+  }
+});

--- a/demo/todo-app/test/todo-store.test.js
+++ b/demo/todo-app/test/todo-store.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { TodoStore, TodoStoreError } from '../src/todo-store.js';
+
+async function createStoreHarness() {
+  const tempDirectory = await mkdtemp(join(tmpdir(), 'todo-store-'));
+  const filePath = join(tempDirectory, 'todos.json');
+
+  return {
+    filePath,
+    store: new TodoStore({ filePath })
+  };
+}
+
+test('todo store persists create, update, and delete operations', async () => {
+  const { filePath, store } = await createStoreHarness();
+
+  const createdTodo = await store.create({ title: 'Write API tests' });
+
+  assert.equal(createdTodo.title, 'Write API tests');
+  assert.equal(createdTodo.completed, false);
+  assert.ok(createdTodo.id);
+  assert.ok(createdTodo.createdAt);
+
+  assert.deepEqual(await store.list(), [createdTodo]);
+
+  const updatedTodo = await store.update(createdTodo.id, {
+    title: 'Write better API tests',
+    completed: true
+  });
+
+  assert.equal(updatedTodo.title, 'Write better API tests');
+  assert.equal(updatedTodo.completed, true);
+
+  const reloadedStore = new TodoStore({ filePath });
+  assert.deepEqual(await reloadedStore.list(), [updatedTodo]);
+
+  const removedTodo = await reloadedStore.remove(createdTodo.id);
+  assert.equal(removedTodo.id, createdTodo.id);
+  assert.deepEqual(await store.list(), []);
+});
+
+test('todo store rejects invalid create and update payloads', async () => {
+  const { store } = await createStoreHarness();
+  const createdTodo = await store.create({ title: 'Valid todo' });
+
+  await assert.rejects(store.create({ title: '   ' }), (error) => {
+    assert.ok(error instanceof TodoStoreError);
+    assert.equal(error.code, 'INVALID_TITLE');
+    return true;
+  });
+
+  await assert.rejects(store.update(createdTodo.id, {}), (error) => {
+    assert.ok(error instanceof TodoStoreError);
+    assert.equal(error.code, 'INVALID_UPDATE');
+    return true;
+  });
+
+  await assert.rejects(store.update(createdTodo.id, { completed: 'yes' }), (error) => {
+    assert.ok(error instanceof TodoStoreError);
+    assert.equal(error.code, 'INVALID_COMPLETED');
+    return true;
+  });
+
+  await assert.rejects(store.update('missing-id', { completed: true }), (error) => {
+    assert.ok(error instanceof TodoStoreError);
+    assert.equal(error.code, 'TODO_NOT_FOUND');
+    return true;
+  });
+});


### PR DESCRIPTION
## Summary
- add a self-contained `demo/todo-app/` Node demo backend so the requested QA coverage has a runnable target
- add store and API tests with Node's built-in test runner for CRUD, persistence, invalid payloads, and error/status cases
- add an isolated `todo-demo.yml` workflow scoped to the demo surfaces only

## Why this PR bundles backend wiring
`main` did not yet contain the `demo/todo-app/` backend surfaces from #15, and there were no open work branches or PRs to stack #18 onto. To keep the QA work runnable instead of speculative, this PR includes the minimal server/store/routes implementation that the tests exercise.

## Notes for reviewers
- `demo/todo-app/package.json` keeps runtime dependencies at zero and uses Node's built-in test runner.
- The workflow is separate from `.github/workflows/orchestrator.yml` and only triggers for demo app changes.
- `public/index.html` is a lightweight placeholder so the demo server can serve `/` until the dedicated frontend work from #17 lands.
