### PR TITLE
docs: document the Todo demo workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This repository has two separate surfaces:
 - **Orchestrator scaffold** for issue-driven agent execution. Start with [SETUP.md](./SETUP.md).
 - **Todo demo workload** under [demo/todo-app/README.md](./demo/todo-app/README.md), a small dependency-light application used to exercise backend, frontend, QA, and docs changes together.
 
-The Todo demo is intentionally isolated from the repository's core orchestration files so it can act as a realistic workload without complicating the scaffold itself. The agreed MVP keeps the stack small: a Python standard-library server, plain HTML/CSS/JS assets, JSON-file persistence, and an isolated demo validation workflow.
+The Todo demo is intentionally isolated from the repository's core orchestration files so it can act as a realistic workload without complicating the scaffold itself. The current demo keeps the stack small: a Python standard-library server, plain HTML/CSS/JS assets, JSON-file persistence, and an isolated demo validation workflow.
 
 Use the scaffold docs when you want to configure automation for another repository. Use the demo docs when you want to run, test, or inspect the Todo example itself.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # gitnative-AI-orchestrator-testing
+
+This repository has two separate surfaces:
+
+- **Orchestrator scaffold** for issue-driven agent execution. Start with [SETUP.md](./SETUP.md).
+- **Todo demo workload** under [demo/todo-app/README.md](./demo/todo-app/README.md), a small dependency-light application used to exercise backend, frontend, QA, and docs changes together.
+
+The Todo demo is intentionally isolated from the repository's core orchestration files so it can act as a realistic workload without complicating the scaffold itself. The agreed MVP keeps the stack small: a Python standard-library server, plain HTML/CSS/JS assets, JSON-file persistence, and an isolated demo validation workflow.
+
+Use the scaffold docs when you want to configure automation for another repository. Use the demo docs when you want to run, test, or inspect the Todo example itself.

--- a/demo/todo-app/README.md
+++ b/demo/todo-app/README.md
@@ -1,6 +1,6 @@
 # Todo Demo
 
-This directory documents the Todo demo planned in issue [#36](../../issues/36). It is the repository's example workload: a small full-stack app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
+This directory documents the Todo demo planned for issue #36. It is the repository's example workload: a small full-stack app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
 
 It is intentionally separate from the repository's orchestrator scaffold:
 
@@ -30,7 +30,7 @@ demo/todo-app/
   data/
     todos.json
   tests/
-    test_server.py
+    test_api.py
 ```
 
 ## Run locally

--- a/demo/todo-app/README.md
+++ b/demo/todo-app/README.md
@@ -1,0 +1,93 @@
+# Todo Demo
+
+This directory documents the Todo demo planned in issue [#36](../../issues/36). It is the repository's example workload: a small full-stack app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
+
+It is intentionally separate from the repository's orchestrator scaffold:
+
+- Use [../../SETUP.md](../../SETUP.md) when configuring orchestration for a repository.
+- Use this README when running, testing, or modifying the Todo demo itself.
+
+## Architecture at a glance
+
+The MVP stays dependency-light because this repository does not have an existing application stack to extend.
+
+- `server.py` serves both static files and the JSON API using Python's standard library.
+- `public/` contains plain HTML, CSS, and JavaScript with no bundler.
+- `data/` stores demo-only JSON state; mutations should rewrite the file atomically.
+- `tests/` uses Python's built-in `unittest` tooling.
+- `.github/workflows/todo-demo.yml` is the planned isolated CI entry point for the demo.
+
+## Planned layout
+
+```text
+demo/todo-app/
+  README.md
+  server.py
+  public/
+    index.html
+    app.js
+    styles.css
+  data/
+    todos.json
+  tests/
+    test_server.py
+```
+
+## Run locally
+
+Use a current Python 3 interpreter.
+
+From the repository root:
+
+```bash
+cd demo/todo-app
+python server.py
+```
+
+The single server process should host both the browser UI and the `/api/todos` endpoints. Open the local URL printed at startup in your browser.
+
+## Run tests
+
+From the repository root:
+
+```bash
+python -m unittest discover -s demo/todo-app/tests -v
+```
+
+The planned CI workflow should run the same demo-focused validation so Todo checks stay separate from `.github/workflows/orchestrator.yml`.
+
+## API contract
+
+Base path: `/api/todos`
+
+| Method | Path | Purpose | Request body |
+| --- | --- | --- | --- |
+| `GET` | `/api/todos` | List all todos | none |
+| `POST` | `/api/todos` | Create a todo | `{ "title": "string" }` |
+| `PATCH` | `/api/todos/{id}` | Update title and/or completion | `{ "title"?: "string", "completed"?: boolean }` |
+| `DELETE` | `/api/todos/{id}` | Delete a todo | none |
+
+Todo items use this MVP shape:
+
+```json
+{
+  "id": "string",
+  "title": "string",
+  "completed": false,
+  "createdAt": "ISO-8601",
+  "updatedAt": "ISO-8601"
+}
+```
+
+Validation errors should return explicit 4xx responses rather than silently accepting bad input.
+
+## Storage behavior
+
+- The JSON store lives under `demo/todo-app/data/`.
+- If the data file does not exist yet, the server should bootstrap an empty todo list.
+- Each create, update, or delete operation should rewrite the file atomically to reduce corruption risk.
+- This storage is for local/demo use only, not durable multi-user infrastructure.
+
+## Why the demo is isolated
+
+This repository is primarily an orchestrator example, not an application repository. Keeping the Todo app inside `demo/todo-app/` avoids coupling app-specific runtime, test, and CI changes to the core scaffold while still providing a realistic end-to-end workload for the agents to coordinate.

--- a/demo/todo-app/README.md
+++ b/demo/todo-app/README.md
@@ -1,10 +1,10 @@
 # Todo Demo
 
-This directory documents the Todo demo planned for issue #36. It is the repository's example workload: a small full-stack app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
+This directory contains the repository's example workload: a small full-stack Todo app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
 
 It is intentionally separate from the repository's orchestrator scaffold:
 
-- Use [../../SETUP.md](../../SETUP.md) when configuring orchestration for a repository.
+- Use [../../SETUP.md](../../SETUP.md) when configuring orchestration for another repository.
 - Use this README when running, testing, or modifying the Todo demo itself.
 
 ## Architecture at a glance
@@ -13,11 +13,11 @@ The MVP stays dependency-light because this repository does not have an existing
 
 - `server.py` serves both static files and the JSON API using Python's standard library.
 - `public/` contains plain HTML, CSS, and JavaScript with no bundler.
-- `data/` stores demo-only JSON state; mutations should rewrite the file atomically.
+- `data/` stores demo-only JSON state; mutations rewrite the file atomically.
 - `tests/` uses Python's built-in `unittest` tooling.
-- `.github/workflows/todo-demo.yml` is the planned isolated CI entry point for the demo.
+- `.github/workflows/todo-demo.yml` runs isolated demo validation without touching `.github/workflows/orchestrator.yml`.
 
-## Planned layout
+## Layout
 
 ```text
 demo/todo-app/
@@ -28,10 +28,14 @@ demo/todo-app/
     app.js
     styles.css
   data/
+    .gitignore
     todos.json
   tests/
-    test_api.py
+    test_server.py
+    test_ui_integration.py
 ```
+
+`todos.json` is runtime state. The repository keeps `data/.gitignore` checked in so local demo data does not get committed.
 
 ## Run locally
 
@@ -44,7 +48,7 @@ cd demo/todo-app
 python server.py
 ```
 
-The single server process should host both the browser UI and the `/api/todos` endpoints. Open the local URL printed at startup in your browser.
+The single server process hosts both the browser UI and the `/api/todos` endpoints. Open the local URL printed at startup in your browser.
 
 ## Run tests
 
@@ -54,7 +58,7 @@ From the repository root:
 python -m unittest discover -s demo/todo-app/tests -v
 ```
 
-The planned CI workflow should run the same demo-focused validation so Todo checks stay separate from `.github/workflows/orchestrator.yml`.
+The dedicated GitHub Actions workflow runs the same command so Todo validation stays separate from orchestrator automation.
 
 ## API contract
 
@@ -79,13 +83,19 @@ Todo items use this MVP shape:
 }
 ```
 
-Validation errors should return explicit 4xx responses rather than silently accepting bad input.
+Validation errors return explicit 4xx JSON responses instead of silently accepting bad input.
+
+## Validation scope and current gaps
+
+- `tests/test_server.py` covers CRUD behavior, validation errors, missing-data bootstrap behavior, malformed storage handling, and static asset serving.
+- `tests/test_ui_integration.py` serves the checked-in HTML/CSS/JS from a live server and verifies that the frontend asset wiring matches the live `/api/todos` contract.
+- Browser-level automation is intentionally omitted. Keeping QA stdlib-only avoids introducing headless-browser dependencies into this repo, but it means real-browser DOM/runtime behavior still relies on manual spot checks if a UI regression is suspected.
 
 ## Storage behavior
 
 - The JSON store lives under `demo/todo-app/data/`.
-- If the data file does not exist yet, the server should bootstrap an empty todo list.
-- Each create, update, or delete operation should rewrite the file atomically to reduce corruption risk.
+- If the data file does not exist yet, the server bootstraps an empty todo list.
+- Each create, update, or delete operation rewrites the file atomically to reduce corruption risk.
 - This storage is for local/demo use only, not durable multi-user infrastructure.
 
 ## Why the demo is isolated


### PR DESCRIPTION
## Summary
- clarify the root README so the repo's orchestrator scaffold and Todo demo are easy to distinguish
- add `demo/todo-app/README.md` covering the agreed MVP architecture, run/test commands, API contract, storage behavior, and isolated CI entry point
- document why the demo stays dependency-light and isolated from the core orchestration scaffold

## Notes
- This PR documents the current MVP contract agreed in #36.
- The implementation PRs for backend, frontend, and QA are still in flight, so this stays draft until those details are confirmed on code.