### PR TITLE
Add plain JS Todo demo UI

### DIFF
--- a/demo/todo-app/public/app.js
+++ b/demo/todo-app/public/app.js
@@ -1,0 +1,359 @@
+(() => {
+  "use strict";
+
+  const state = {
+    todos: [],
+    loading: true,
+    creating: false,
+    savingIds: new Set(),
+    editingId: null,
+  };
+
+  const todoForm = document.querySelector("#todo-form");
+  const titleInput = document.querySelector("#todo-title");
+  const addButton = document.querySelector("#add-button");
+  const refreshButton = document.querySelector("#refresh-button");
+  const statusMessage = document.querySelector("#status-message");
+  const errorMessage = document.querySelector("#error-message");
+  const loadingState = document.querySelector("#loading-state");
+  const emptyState = document.querySelector("#empty-state");
+  const todoList = document.querySelector("#todo-list");
+  const itemTemplate = document.querySelector("#todo-item-template");
+
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+  function setStatus(message) {
+    statusMessage.textContent = message;
+  }
+
+  function clearError() {
+    errorMessage.hidden = true;
+    errorMessage.textContent = "";
+  }
+
+  function showError(message) {
+    errorMessage.hidden = false;
+    errorMessage.textContent = message;
+    setStatus("A request failed. Review the error message and try again.");
+  }
+
+  function setBusy(id, busy) {
+    if (busy) {
+      state.savingIds.add(id);
+    } else {
+      state.savingIds.delete(id);
+    }
+  }
+
+  function isBusy(id) {
+    return state.savingIds.has(id);
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return "";
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return "";
+    }
+
+    return dateFormatter.format(date);
+  }
+
+  function formatTodoMeta(todo) {
+    const details = [todo.completed ? "Completed" : "Open"];
+    const createdAt = formatDate(todo.createdAt);
+    const updatedAt = formatDate(todo.updatedAt);
+
+    if (createdAt) {
+      details.push(`Created ${createdAt}`);
+    }
+
+    if (updatedAt && updatedAt !== createdAt) {
+      details.push(`Updated ${updatedAt}`);
+    }
+
+    return details.join(" · ");
+  }
+
+  async function request(path, options = {}) {
+    const config = {
+      headers: {
+        Accept: "application/json",
+      },
+      ...options,
+    };
+
+    if (config.body) {
+      config.headers = {
+        ...config.headers,
+        "Content-Type": "application/json",
+      };
+    }
+
+    const response = await fetch(path, config);
+    const text = await response.text();
+    let payload = null;
+
+    if (text) {
+      try {
+        payload = JSON.parse(text);
+      } catch (error) {
+        payload = null;
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload && typeof payload.error === "string"
+        ? payload.error
+        : `Request failed with status ${response.status}.`;
+      throw new Error(message);
+    }
+
+    return payload;
+  }
+
+  function normalizeTodos(payload) {
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (payload && Array.isArray(payload.todos)) {
+      return payload.todos;
+    }
+
+    return [];
+  }
+
+  function render() {
+    const hasTodos = state.todos.length > 0;
+
+    loadingState.hidden = !state.loading;
+    emptyState.hidden = state.loading || hasTodos;
+    todoList.hidden = state.loading || !hasTodos;
+    addButton.disabled = state.creating;
+    titleInput.disabled = state.creating;
+    refreshButton.disabled = state.loading || state.creating || state.savingIds.size > 0;
+
+    todoList.replaceChildren();
+
+    for (const todo of state.todos) {
+      const item = itemTemplate.content.firstElementChild.cloneNode(true);
+      const isEditing = state.editingId === todo.id;
+      const busy = isBusy(todo.id);
+      const toggle = item.querySelector(".todo-toggle");
+      const title = item.querySelector(".todo-title");
+      const meta = item.querySelector(".todo-meta");
+      const editButton = item.querySelector(".edit-button");
+      const deleteButton = item.querySelector(".delete-button");
+      const view = item.querySelector(".todo-view");
+      const editForm = item.querySelector(".edit-form");
+      const editInput = item.querySelector(".edit-input");
+      const cancelButton = item.querySelector(".cancel-edit-button");
+      const saveButton = item.querySelector(".save-button");
+
+      item.dataset.todoId = todo.id;
+      item.dataset.editing = String(isEditing);
+      item.classList.toggle("is-complete", Boolean(todo.completed));
+
+      toggle.checked = Boolean(todo.completed);
+      toggle.disabled = busy;
+      title.textContent = todo.title;
+      meta.textContent = formatTodoMeta(todo);
+      editButton.disabled = busy;
+      deleteButton.disabled = busy;
+      saveButton.disabled = busy;
+      cancelButton.disabled = busy;
+
+      view.hidden = isEditing;
+      editForm.hidden = !isEditing;
+      editInput.value = todo.title;
+      editInput.disabled = busy;
+
+      toggle.addEventListener("change", () => {
+        handleToggle(todo, toggle.checked);
+      });
+
+      editButton.addEventListener("click", () => {
+        clearError();
+        state.editingId = todo.id;
+        setStatus(`Editing \"${todo.title}\".`);
+        render();
+      });
+
+      deleteButton.addEventListener("click", () => {
+        handleDelete(todo);
+      });
+
+      cancelButton.addEventListener("click", () => {
+        state.editingId = null;
+        setStatus(`Canceled changes for \"${todo.title}\".`);
+        render();
+      });
+
+      editForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        handleEdit(todo, editInput.value);
+      });
+
+      todoList.appendChild(item);
+    }
+
+    const editingInput = todoList.querySelector('.todo-item[data-editing="true"] .edit-input');
+    if (editingInput) {
+      editingInput.focus();
+      editingInput.select();
+    }
+  }
+
+  async function loadTodos({ announceLoading = true, successMessage = "" } = {}) {
+    state.loading = true;
+
+    if (announceLoading) {
+      setStatus("Loading todos...");
+    }
+
+    clearError();
+    render();
+
+    try {
+      const payload = await request("/api/todos");
+      state.todos = normalizeTodos(payload);
+
+      if (successMessage) {
+        setStatus(successMessage);
+      } else if (state.todos.length === 0) {
+        setStatus("No todos yet. Add your first task above.");
+      } else {
+        const count = state.todos.length;
+        setStatus(`Loaded ${count} todo${count === 1 ? "" : "s"}.`);
+      }
+    } catch (error) {
+      state.todos = [];
+      showError(error instanceof Error ? error.message : "Unable to load todos.");
+    } finally {
+      state.loading = false;
+      render();
+    }
+  }
+
+  async function handleCreate(event) {
+    event.preventDefault();
+
+    const title = titleInput.value.trim();
+    if (!title) {
+      showError("Enter a title before adding a todo.");
+      titleInput.focus();
+      return;
+    }
+
+    state.creating = true;
+    clearError();
+    setStatus("Adding todo...");
+    render();
+
+    try {
+      await request("/api/todos", {
+        method: "POST",
+        body: JSON.stringify({ title }),
+      });
+      todoForm.reset();
+      await loadTodos({ announceLoading: false, successMessage: "Todo added." });
+      titleInput.focus();
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to add todo.");
+    } finally {
+      state.creating = false;
+      render();
+    }
+  }
+
+  async function handleToggle(todo, completed) {
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(completed ? `Marking \"${todo.title}\" complete...` : `Reopening \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ completed }),
+      });
+      await loadTodos({
+        announceLoading: false,
+        successMessage: completed ? "Todo marked complete." : "Todo marked active.",
+      });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to update todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  async function handleEdit(todo, nextTitle) {
+    const title = nextTitle.trim();
+    if (!title) {
+      showError("Todo titles cannot be empty.");
+      return;
+    }
+
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(`Saving \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ title }),
+      });
+      state.editingId = null;
+      await loadTodos({ announceLoading: false, successMessage: "Todo updated." });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to update todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  async function handleDelete(todo) {
+    const confirmed = window.confirm(`Delete \"${todo.title}\"?`);
+    if (!confirmed) {
+      return;
+    }
+
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(`Deleting \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "DELETE",
+      });
+      if (state.editingId === todo.id) {
+        state.editingId = null;
+      }
+      await loadTodos({ announceLoading: false, successMessage: "Todo deleted." });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to delete todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  refreshButton.addEventListener("click", () => {
+    loadTodos();
+  });
+
+  todoForm.addEventListener("submit", handleCreate);
+  loadTodos();
+})();

--- a/demo/todo-app/public/index.html
+++ b/demo/todo-app/public/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Todo Demo</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./app.js" defer></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="app-header">
+        <p class="eyebrow">Todo demo</p>
+        <h1>Track a small list without extra tooling</h1>
+        <p class="app-copy">
+          This MVP uses the demo CRUD API to create, edit, complete, refresh, and delete tasks from a single page.
+        </p>
+      </header>
+
+      <noscript>
+        <p class="panel noscript-message">This demo requires JavaScript to load and update todos.</p>
+      </noscript>
+
+      <section class="panel controls-panel" aria-labelledby="create-heading">
+        <h2 id="create-heading">Add a task</h2>
+        <form id="todo-form" class="todo-form">
+          <label class="sr-only" for="todo-title">Task title</label>
+          <div class="input-row">
+            <input
+              id="todo-title"
+              name="title"
+              type="text"
+              maxlength="120"
+              autocomplete="off"
+              placeholder="What needs doing?"
+              required
+            />
+            <button id="add-button" type="submit">Add todo</button>
+          </div>
+          <p class="field-hint">Use a short title so the inline edit flow stays easy to scan.</p>
+        </form>
+      </section>
+
+      <section class="panel status-panel" aria-live="polite" aria-atomic="true">
+        <p id="status-message" class="status-message">Loading todos...</p>
+        <p id="error-message" class="error-message" role="alert" hidden></p>
+      </section>
+
+      <section class="panel list-panel" aria-labelledby="todos-heading">
+        <div class="list-heading">
+          <h2 id="todos-heading">Tasks</h2>
+          <button id="refresh-button" class="secondary-button" type="button">Refresh</button>
+        </div>
+
+        <div id="loading-state" class="empty-state">Loading todos...</div>
+        <div id="empty-state" class="empty-state" hidden>No todos yet. Add your first task above.</div>
+        <ul id="todo-list" class="todo-list" aria-describedby="status-message" hidden></ul>
+      </section>
+    </main>
+
+    <template id="todo-item-template">
+      <li class="todo-item">
+        <div class="todo-view">
+          <div class="todo-main">
+            <label class="toggle-row">
+              <input class="todo-toggle" type="checkbox" />
+              <span class="todo-title"></span>
+            </label>
+            <p class="todo-meta"></p>
+          </div>
+          <div class="todo-actions">
+            <button class="secondary-button edit-button" type="button">Edit</button>
+            <button class="danger-button delete-button" type="button">Delete</button>
+          </div>
+        </div>
+
+        <form class="edit-form" hidden>
+          <label class="sr-only">Edit task title</label>
+          <div class="input-row">
+            <input class="edit-input" name="title" type="text" maxlength="120" required aria-label="Edit task title" />
+            <button class="save-button" type="submit">Save</button>
+            <button class="secondary-button cancel-edit-button" type="button">Cancel</button>
+          </div>
+        </form>
+      </li>
+    </template>
+  </body>
+</html>

--- a/demo/todo-app/public/styles.css
+++ b/demo/todo-app/public/styles.css
@@ -1,0 +1,294 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background: #f3f4f6;
+  color: #111827;
+  --panel-border: #d1d5db;
+  --panel-background: #ffffff;
+  --muted: #6b7280;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --success: #166534;
+  --error-bg: #fef2f2;
+  --error-text: #991b1b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #eff6ff 0%, #f9fafb 48%, #f3f4f6 100%);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  background: var(--primary);
+  color: #ffffff;
+  cursor: pointer;
+  padding: 0.8rem 1rem;
+  transition: background-color 160ms ease, border-color 160ms ease, opacity 160ms ease;
+}
+
+button:hover {
+  background: var(--primary-hover);
+}
+
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.25);
+  outline-offset: 2px;
+}
+
+input {
+  width: 100%;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.75rem;
+  padding: 0.8rem 0.9rem;
+  background: #ffffff;
+  color: inherit;
+}
+
+.app-shell {
+  width: min(100%, 48rem);
+  margin: 0 auto;
+  padding: 2.5rem 1rem 3rem;
+}
+
+.app-header {
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--primary);
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.1;
+}
+
+h2 {
+  margin-bottom: 0.9rem;
+  font-size: 1.125rem;
+}
+
+.app-copy,
+.field-hint,
+.todo-meta,
+.status-message {
+  color: var(--muted);
+}
+
+.panel {
+  background: var(--panel-background);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  padding: 1.1rem;
+}
+
+.panel + .panel {
+  margin-top: 1rem;
+}
+
+.noscript-message {
+  margin-bottom: 1rem;
+}
+
+.input-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.todo-form .input-row input,
+.edit-form .input-row input {
+  flex: 1;
+}
+
+.list-heading,
+.todo-view,
+.todo-actions {
+  display: flex;
+  align-items: center;
+}
+
+.list-heading {
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.empty-state {
+  padding: 1rem;
+  border: 1px dashed var(--panel-border);
+  border-radius: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.todo-item {
+  border: 1px solid var(--panel-border);
+  border-radius: 0.9rem;
+  padding: 0.95rem;
+  background: #f9fafb;
+}
+
+.todo-item[data-editing="true"] {
+  background: #eff6ff;
+}
+
+.todo-view {
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.todo-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.toggle-row {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.todo-toggle {
+  margin-top: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+}
+
+.todo-title {
+  overflow-wrap: anywhere;
+}
+
+.todo-item.is-complete .todo-title {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+
+.todo-meta {
+  margin: 0.4rem 0 0;
+  font-size: 0.92rem;
+}
+
+.todo-actions {
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.secondary-button {
+  background: #ffffff;
+  color: #1f2937;
+  border-color: var(--panel-border);
+}
+
+.secondary-button:hover {
+  background: #f3f4f6;
+}
+
+.danger-button {
+  background: #ffffff;
+  color: var(--danger);
+  border-color: #fecaca;
+}
+
+.danger-button:hover {
+  background: #fef2f2;
+  color: var(--danger-hover);
+}
+
+.edit-form {
+  margin-top: 0.9rem;
+}
+
+.error-message {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  background: var(--error-bg);
+  color: var(--error-text);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding-top: 1.5rem;
+  }
+
+  .input-row,
+  .todo-view {
+    flex-direction: column;
+  }
+
+  .todo-actions {
+    justify-content: flex-start;
+  }
+
+  .list-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dependency-light Todo demo UI under `demo/todo-app/public/`
- implement create, refresh, edit, toggle-complete, and delete flows against `/api/todos`
- include loading, empty, and visible error states with accessible form controls and live status updates

## UX notes
- single-page HTML/CSS/JS only; no frontend build step required
- uses immediate refresh after each mutation to stay aligned with backend persistence
- accepts either a raw array response or `{ "todos": [...] }` for `GET /api/todos` to keep the handoff resilient while backend work lands

Closes #39