### PR TITLE
Add isolated Todo demo backend

### DIFF
--- a/demo/todo-app/data/.gitignore
+++ b/demo/todo-app/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/demo/todo-app/server.py
+++ b/demo/todo-app/server.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""Dependency-light Todo demo server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import tempfile
+import threading
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit
+from uuid import uuid4
+
+MAX_TITLE_LENGTH = 120
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_DATA_FILE = Path(__file__).with_name("data") / "todos.json"
+DEFAULT_PUBLIC_DIR = Path(__file__).with_name("public")
+
+
+class RequestValidationError(Exception):
+    """Raised when a request body or path is invalid."""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def require_json_object(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RequestValidationError("Request body must be a JSON object.")
+    return payload
+
+
+def validate_title(value: Any) -> str:
+    if not isinstance(value, str):
+        raise RequestValidationError("Field 'title' must be a string.")
+
+    title = value.strip()
+    if not title:
+        raise RequestValidationError("Field 'title' cannot be empty.")
+    if len(title) > MAX_TITLE_LENGTH:
+        raise RequestValidationError(
+            f"Field 'title' must be {MAX_TITLE_LENGTH} characters or fewer."
+        )
+    return title
+
+
+def validate_create_payload(payload: Any) -> dict[str, Any]:
+    document = require_json_object(payload)
+    allowed_keys = {"title"}
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise RequestValidationError(
+            f"Unsupported fields for todo creation: {', '.join(unknown_keys)}."
+        )
+    if "title" not in document:
+        raise RequestValidationError("Field 'title' is required.")
+    return {"title": validate_title(document["title"])}
+
+
+def validate_update_payload(payload: Any) -> dict[str, Any]:
+    document = require_json_object(payload)
+    allowed_keys = {"title", "completed"}
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise RequestValidationError(
+            f"Unsupported fields for todo updates: {', '.join(unknown_keys)}."
+        )
+    if not document:
+        raise RequestValidationError(
+            "Provide at least one of 'title' or 'completed' to update a todo."
+        )
+
+    updates: dict[str, Any] = {}
+    if "title" in document:
+        updates["title"] = validate_title(document["title"])
+    if "completed" in document:
+        if type(document["completed"]) is not bool:
+            raise RequestValidationError("Field 'completed' must be a boolean.")
+        updates["completed"] = document["completed"]
+
+    return updates
+
+
+def validate_todo_item(item: Any) -> dict[str, Any]:
+    todo = require_json_object(item)
+    required_keys = {"id", "title", "completed", "createdAt", "updatedAt"}
+    if set(todo) != required_keys:
+        raise ValueError("Todo items in storage must match the expected contract.")
+    if not isinstance(todo["id"], str) or not todo["id"]:
+        raise ValueError("Todo 'id' values must be non-empty strings.")
+    if type(todo["completed"]) is not bool:
+        raise ValueError("Todo 'completed' values must be booleans.")
+
+    return {
+        "id": todo["id"],
+        "title": validate_title(todo["title"]),
+        "completed": todo["completed"],
+        "createdAt": str(todo["createdAt"]),
+        "updatedAt": str(todo["updatedAt"]),
+    }
+
+
+class TodoStore:
+    """File-backed Todo persistence with atomic writes."""
+
+    def __init__(self, data_file: Path) -> None:
+        self.data_file = data_file
+        self._lock = threading.Lock()
+
+    def _bootstrap_if_needed(self) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        if not self.data_file.exists():
+            self._write_locked([])
+
+    def _read_locked(self) -> list[dict[str, Any]]:
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, list):
+            raise ValueError("Todo storage must contain a JSON array.")
+        return [validate_todo_item(item) for item in payload]
+
+    def _write_locked(self, todos: list[dict[str, Any]]) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            dir=str(self.data_file.parent),
+            prefix=f"{self.data_file.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+                json.dump(todos, handle, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, self.data_file)
+        except Exception:
+            if os.path.exists(temporary_path):
+                os.unlink(temporary_path)
+            raise
+
+    def list_todos(self) -> list[dict[str, Any]]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            return self._read_locked()
+
+    def create_todo(self, title: str) -> dict[str, Any]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            timestamp = utc_now_iso()
+            todo = {
+                "id": uuid4().hex,
+                "title": title,
+                "completed": False,
+                "createdAt": timestamp,
+                "updatedAt": timestamp,
+            }
+            todos.append(todo)
+            self._write_locked(todos)
+            return todo
+
+    def update_todo(self, todo_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            for index, todo in enumerate(todos):
+                if todo["id"] != todo_id:
+                    continue
+
+                updated = dict(todo)
+                updated.update(updates)
+                updated["updatedAt"] = utc_now_iso()
+                todos[index] = updated
+                self._write_locked(todos)
+                return updated
+
+        raise KeyError(todo_id)
+
+    def delete_todo(self, todo_id: str) -> None:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            remaining = [todo for todo in todos if todo["id"] != todo_id]
+            if len(remaining) == len(todos):
+                raise KeyError(todo_id)
+            self._write_locked(remaining)
+
+
+def parse_todo_id(path: str) -> str | None:
+    if not path.startswith("/api/todos/"):
+        return None
+    todo_id = path.removeprefix("/api/todos/")
+    if not todo_id or "/" in todo_id:
+        return None
+    return unquote(todo_id)
+
+
+def build_handler(
+    store: TodoStore,
+    public_dir: Path,
+) -> type[BaseHTTPRequestHandler]:
+    class TodoRequestHandler(BaseHTTPRequestHandler):
+        server_version = "TodoDemo/1.0"
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            if parsed.path == "/api/todos":
+                self._handle_list_todos()
+                return
+            if parsed.path.startswith("/api/"):
+                self._send_api_error(HTTPStatus.NOT_FOUND, "API route not found.")
+                return
+            self._serve_static(parsed.path)
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            if parsed.path != "/api/todos":
+                self._send_api_error(HTTPStatus.NOT_FOUND, "API route not found.")
+                return
+
+            try:
+                payload = self._read_json_body()
+                todo = store.create_todo(validate_create_payload(payload)["title"])
+            except RequestValidationError as error:
+                self._send_api_error(HTTPStatus.BAD_REQUEST, str(error))
+                return
+            except OSError as error:
+                self._send_api_error(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    f"Unable to persist todo data: {error}",
+                )
+                return
+
+            self._send_json(HTTPStatus.CREATED, todo)
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            todo_id = parse_todo_id(parsed.path)
+            if todo_id is None:
+                self._send_api_error(HTTPStatus.NOT_FOUND, "Todo route not found.")
+                return
+
+            try:
+                payload = self._read_json_body()
+                todo = store.update_todo(todo_id, validate_update_payload(payload))
+            except RequestValidationError as error:
+                self._send_api_error(HTTPStatus.BAD_REQUEST, str(error))
+                return
+            except KeyError:
+                self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
+                return
+            except OSError as error:
+                self._send_api_error(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    f"Unable to persist todo data: {error}",
+                )
+                return
+
+            self._send_json(HTTPStatus.OK, todo)
+
+        def do_DELETE(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            todo_id = parse_todo_id(parsed.path)
+            if todo_id is None:
+                self._send_api_error(HTTPStatus.NOT_FOUND, "Todo route not found.")
+                return
+
+            try:
+                store.delete_todo(todo_id)
+            except KeyError:
+                self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
+                return
+            except OSError as error:
+                self._send_api_error(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    f"Unable to persist todo data: {error}",
+                )
+                return
+
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.end_headers()
+
+        def _handle_list_todos(self) -> None:
+            try:
+                todos = store.list_todos()
+            except (OSError, ValueError) as error:
+                self._send_api_error(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    f"Unable to load todo data: {error}",
+                )
+                return
+
+            self._send_json(HTTPStatus.OK, {"todos": todos})
+
+        def _read_json_body(self) -> Any:
+            raw_length = self.headers.get("Content-Length")
+            if raw_length is None:
+                raise RequestValidationError("Requests with a body must send Content-Length.")
+
+            try:
+                content_length = int(raw_length)
+            except ValueError as error:
+                raise RequestValidationError("Content-Length must be a valid integer.") from error
+
+            if content_length <= 0:
+                raise RequestValidationError("Request body cannot be empty.")
+
+            body = self.rfile.read(content_length)
+            try:
+                text = body.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise RequestValidationError("Request bodies must be valid UTF-8.") from error
+
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError as error:
+                raise RequestValidationError("Request body must contain valid JSON.") from error
+
+        def _serve_static(self, request_path: str) -> None:
+            candidate = self._resolve_public_path(request_path)
+            if candidate is None or not candidate.is_file():
+                self.send_error(HTTPStatus.NOT_FOUND, "File not found.")
+                return
+
+            content_type, _ = mimetypes.guess_type(candidate.name)
+            with candidate.open("rb") as handle:
+                content = handle.read()
+
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type or "application/octet-stream")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+
+        def _resolve_public_path(self, request_path: str) -> Path | None:
+            relative_path = request_path.lstrip("/")
+            if not relative_path:
+                relative_path = "index.html"
+
+            resolved = (public_dir / relative_path).resolve()
+            public_root = public_dir.resolve()
+            if resolved != public_root and public_root not in resolved.parents:
+                return None
+            if resolved.is_dir():
+                resolved = (resolved / "index.html").resolve()
+                if resolved != public_root and public_root not in resolved.parents:
+                    return None
+            return resolved
+
+        def _send_json(self, status: HTTPStatus, payload: Any) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_api_error(self, status: HTTPStatus, message: str) -> None:
+            self._send_json(status, {"error": message})
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return TodoRequestHandler
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Serve the Todo demo API and static assets.")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Interface to bind to.")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="Port to bind to.",
+    )
+    parser.add_argument(
+        "--data-file",
+        type=Path,
+        default=DEFAULT_DATA_FILE,
+        help="Path to the JSON file used for Todo persistence.",
+    )
+    parser.add_argument(
+        "--public-dir",
+        type=Path,
+        default=DEFAULT_PUBLIC_DIR,
+        help="Directory containing static UI assets.",
+    )
+    return parser.parse_args()
+
+
+def run_server(host: str, port: int, data_file: Path, public_dir: Path) -> None:
+    store = TodoStore(data_file)
+    public_dir.mkdir(parents=True, exist_ok=True)
+    with ThreadingHTTPServer((host, port), build_handler(store, public_dir)) as server:
+        bound_host, bound_port = server.server_address[:2]
+        print(
+            f"Todo demo available at http://{bound_host}:{bound_port} "
+            f"(data: {data_file}, public: {public_dir})"
+        )
+        server.serve_forever()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    run_server(
+        host=arguments.host,
+        port=arguments.port,
+        data_file=arguments.data_file,
+        public_dir=arguments.public_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/todo-app/server.py
+++ b/demo/todo-app/server.py
@@ -90,18 +90,22 @@ def validate_update_payload(payload: Any) -> dict[str, Any]:
 
 
 def validate_todo_item(item: Any) -> dict[str, Any]:
-    todo = require_json_object(item)
-    required_keys = {"id", "title", "completed", "createdAt", "updatedAt"}
-    if set(todo) != required_keys:
-        raise ValueError("Todo items in storage must match the expected contract.")
-    if not isinstance(todo["id"], str) or not todo["id"]:
-        raise ValueError("Todo 'id' values must be non-empty strings.")
-    if type(todo["completed"]) is not bool:
-        raise ValueError("Todo 'completed' values must be booleans.")
+    try:
+        todo = require_json_object(item)
+        required_keys = {"id", "title", "completed", "createdAt", "updatedAt"}
+        if set(todo) != required_keys:
+            raise ValueError("Todo items in storage must match the expected contract.")
+        if not isinstance(todo["id"], str) or not todo["id"]:
+            raise ValueError("Todo 'id' values must be non-empty strings.")
+        if type(todo["completed"]) is not bool:
+            raise ValueError("Todo 'completed' values must be booleans.")
+        title = validate_title(todo["title"])
+    except RequestValidationError as error:
+        raise ValueError(str(error)) from error
 
     return {
         "id": todo["id"],
-        "title": validate_title(todo["title"]),
+        "title": title,
         "completed": todo["completed"],
         "createdAt": str(todo["createdAt"]),
         "updatedAt": str(todo["updatedAt"]),
@@ -232,11 +236,11 @@ def build_handler(
             except RequestValidationError as error:
                 self._send_api_error(HTTPStatus.BAD_REQUEST, str(error))
                 return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
             except OSError as error:
-                self._send_api_error(
-                    HTTPStatus.INTERNAL_SERVER_ERROR,
-                    f"Unable to persist todo data: {error}",
-                )
+                self._handle_storage_write_error(error)
                 return
 
             self._send_json(HTTPStatus.CREATED, todo)
@@ -257,11 +261,11 @@ def build_handler(
             except KeyError:
                 self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
                 return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
             except OSError as error:
-                self._send_api_error(
-                    HTTPStatus.INTERNAL_SERVER_ERROR,
-                    f"Unable to persist todo data: {error}",
-                )
+                self._handle_storage_write_error(error)
                 return
 
             self._send_json(HTTPStatus.OK, todo)
@@ -278,11 +282,11 @@ def build_handler(
             except KeyError:
                 self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
                 return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
             except OSError as error:
-                self._send_api_error(
-                    HTTPStatus.INTERNAL_SERVER_ERROR,
-                    f"Unable to persist todo data: {error}",
-                )
+                self._handle_storage_write_error(error)
                 return
 
             self.send_response(HTTPStatus.NO_CONTENT)
@@ -292,10 +296,7 @@ def build_handler(
             try:
                 todos = store.list_todos()
             except (OSError, ValueError) as error:
-                self._send_api_error(
-                    HTTPStatus.INTERNAL_SERVER_ERROR,
-                    f"Unable to load todo data: {error}",
-                )
+                self._handle_storage_load_error(error)
                 return
 
             self._send_json(HTTPStatus.OK, {"todos": todos})
@@ -365,6 +366,18 @@ def build_handler(
 
         def _send_api_error(self, status: HTTPStatus, message: str) -> None:
             self._send_json(status, {"error": message})
+
+        def _handle_storage_load_error(self, error: Exception) -> None:
+            self._send_api_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"Unable to load todo data: {error}",
+            )
+
+        def _handle_storage_write_error(self, error: OSError) -> None:
+            self._send_api_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"Unable to persist todo data: {error}",
+            )
 
         def log_message(self, format: str, *args: Any) -> None:
             return

--- a/demo/todo-app/tests/test_server.py
+++ b/demo/todo-app/tests/test_server.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+SPEC = importlib.util.spec_from_file_location("todo_demo_server", SERVER_PATH)
+SERVER = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(SERVER)
+
+
+class TodoServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.public_dir = self.root / "public"
+        self.public_dir.mkdir(parents=True)
+        (self.public_dir / "index.html").write_text(
+            "<!doctype html><title>Todo Demo</title><h1>Hello</h1>",
+            encoding="utf-8",
+        )
+        self.data_file = self.root / "data" / "todos.json"
+        self.store = SERVER.TodoStore(self.data_file)
+        self.server = SERVER.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            SERVER.build_handler(self.store, self.public_dir),
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.temporary_directory.cleanup()
+
+    def request(self, method: str, path: str, payload: dict | None = None) -> tuple[int, dict, bytes]:
+        body = None
+        headers = {}
+        if payload is not None:
+            body = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+
+        request = Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers=headers,
+            method=method,
+        )
+
+        try:
+            with urlopen(request) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except HTTPError as error:
+            return error.code, dict(error.headers.items()), error.read()
+
+    def request_json(self, method: str, path: str, payload: dict | None = None) -> tuple[int, dict]:
+        status, _, body = self.request(method, path, payload)
+        document = json.loads(body.decode("utf-8")) if body else {}
+        return status, document
+
+    def test_get_bootstraps_missing_data_file(self) -> None:
+        status, payload = self.request_json("GET", "/api/todos")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"todos": []})
+        self.assertTrue(self.data_file.exists())
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [])
+
+    def test_crud_round_trip_persists_updates(self) -> None:
+        status, created = self.request_json("POST", "/api/todos", {"title": "Write tests"})
+        self.assertEqual(status, 201)
+        self.assertEqual(created["title"], "Write tests")
+        self.assertFalse(created["completed"])
+
+        todo_id = created["id"]
+
+        status, updated = self.request_json(
+            "PATCH",
+            f"/api/todos/{todo_id}",
+            {"title": "Ship demo", "completed": True},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(updated["title"], "Ship demo")
+        self.assertTrue(updated["completed"])
+        self.assertNotEqual(updated["updatedAt"], updated["createdAt"])
+
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [updated])
+
+        status, listed = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(listed, {"todos": [updated]})
+
+        status, _, body = self.request("DELETE", f"/api/todos/{todo_id}")
+        self.assertEqual(status, 204)
+        self.assertEqual(body, b"")
+
+        status, final_payload = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(final_payload, {"todos": []})
+
+    def test_validation_errors_are_explicit(self) -> None:
+        status, payload = self.request_json("POST", "/api/todos", {"title": "   "})
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Field 'title' cannot be empty.")
+
+        status, payload = self.request_json("PATCH", "/api/todos/missing", {"completed": True})
+        self.assertEqual(status, 404)
+        self.assertEqual(payload["error"], "Todo 'missing' was not found.")
+
+        status, payload = self.request_json("POST", "/api/todos", {"title": "Valid"})
+        todo_id = payload["id"]
+
+        status, payload = self.request_json(
+            "PATCH",
+            f"/api/todos/{todo_id}",
+            {"completed": 1},
+        )
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Field 'completed' must be a boolean.")
+
+        status, payload = self.request_json("PATCH", f"/api/todos/{todo_id}", {})
+        self.assertEqual(status, 400)
+        self.assertIn("Provide at least one", payload["error"])
+
+    def test_static_files_are_served_from_public_dir(self) -> None:
+        (self.public_dir / "styles.css").write_text("body { color: #111; }", encoding="utf-8")
+
+        status, headers, body = self.request("GET", "/")
+        self.assertEqual(status, 200)
+        self.assertIn("text/html", headers["Content-Type"])
+        self.assertIn(b"Todo Demo", body)
+
+        status, headers, body = self.request("GET", "/styles.css")
+        self.assertEqual(status, 200)
+        self.assertIn("text/css", headers["Content-Type"])
+        self.assertEqual(body, b"body { color: #111; }")
+
+        status, _, _ = self.request("GET", "/../server.py")
+        self.assertEqual(status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/demo/todo-app/tests/test_server.py
+++ b/demo/todo-app/tests/test_server.py
@@ -43,17 +43,27 @@ class TodoServerTests(unittest.TestCase):
         self.thread.join(timeout=5)
         self.temporary_directory.cleanup()
 
-    def request(self, method: str, path: str, payload: dict | None = None) -> tuple[int, dict, bytes]:
-        body = None
-        headers = {}
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, dict, bytes]:
+        if payload is not None and body is not None:
+            raise ValueError("Use either 'payload' or 'body', not both.")
+
+        request_body = body
+        request_headers = dict(headers or {})
         if payload is not None:
-            body = json.dumps(payload).encode("utf-8")
-            headers["Content-Type"] = "application/json"
+            request_body = json.dumps(payload).encode("utf-8")
+            request_headers.setdefault("Content-Type", "application/json")
 
         request = Request(
             f"{self.base_url}{path}",
-            data=body,
-            headers=headers,
+            data=request_body,
+            headers=request_headers,
             method=method,
         )
 
@@ -68,6 +78,10 @@ class TodoServerTests(unittest.TestCase):
         document = json.loads(body.decode("utf-8")) if body else {}
         return status, document
 
+    def write_storage(self, payload: object) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        self.data_file.write_text(json.dumps(payload), encoding="utf-8")
+
     def test_get_bootstraps_missing_data_file(self) -> None:
         status, payload = self.request_json("GET", "/api/todos")
 
@@ -76,6 +90,15 @@ class TodoServerTests(unittest.TestCase):
         self.assertTrue(self.data_file.exists())
         stored = json.loads(self.data_file.read_text(encoding="utf-8"))
         self.assertEqual(stored, [])
+
+    def test_post_bootstraps_missing_data_file(self) -> None:
+        status, created = self.request_json("POST", "/api/todos", {"title": "Write tests"})
+
+        self.assertEqual(status, 201)
+        self.assertEqual(created["title"], "Write tests")
+        self.assertTrue(self.data_file.exists())
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [created])
 
     def test_crud_round_trip_persists_updates(self) -> None:
         status, created = self.request_json("POST", "/api/todos", {"title": "Write tests"})
@@ -133,6 +156,45 @@ class TodoServerTests(unittest.TestCase):
         status, payload = self.request_json("PATCH", f"/api/todos/{todo_id}", {})
         self.assertEqual(status, 400)
         self.assertIn("Provide at least one", payload["error"])
+
+    def test_invalid_json_request_body_returns_400(self) -> None:
+        status, _, body = self.request(
+            "POST",
+            "/api/todos",
+            body=b"{",
+            headers={"Content-Type": "application/json"},
+        )
+        payload = json.loads(body.decode("utf-8"))
+
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Request body must contain valid JSON.")
+
+    def test_mutations_report_malformed_storage_as_json_errors(self) -> None:
+        malformed_todos = [
+            {
+                "id": "todo-1",
+                "title": 99,
+                "completed": False,
+                "createdAt": "2026-04-18T00:00:00Z",
+                "updatedAt": "2026-04-18T00:00:00Z",
+            }
+        ]
+        scenarios = [
+            ("POST", "/api/todos", {"title": "Create todo"}),
+            ("PATCH", "/api/todos/todo-1", {"completed": True}),
+            ("DELETE", "/api/todos/todo-1", None),
+        ]
+
+        for method, path, payload in scenarios:
+            with self.subTest(method=method):
+                self.write_storage(malformed_todos)
+                status, response = self.request_json(method, path, payload)
+
+                self.assertEqual(status, 500)
+                self.assertEqual(
+                    response,
+                    {"error": "Unable to load todo data: Field 'title' must be a string."},
+                )
 
     def test_static_files_are_served_from_public_dir(self) -> None:
         (self.public_dir / "styles.css").write_text("body { color: #111; }", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `demo/todo-app/server.py` with a Python standard-library HTTP server that serves both static files and the Todo CRUD API
- add file-backed persistence with atomic JSON rewrites plus bootstrap behavior when `demo/todo-app/data/todos.json` does not exist yet
- add focused unittest coverage for CRUD flows, validation errors, bootstrap behavior, and static asset serving

## API contract
Base path: `/api/todos`

| Method | Path | Success response | Notes |
| --- | --- | --- | --- |
| `GET` | `/api/todos` | `200 { "todos": Todo[] }` | Returns the full current list |
| `POST` | `/api/todos` | `201 Todo` | Accepts `{ "title": string }` |
| `PATCH` | `/api/todos/{id}` | `200 Todo` | Accepts one or both of `{ "title": string, "completed": boolean }` |
| `DELETE` | `/api/todos/{id}` | `204` | Empty response body |

`Todo` shape:

```json
{
  "id": "string",
  "title": "string",
  "completed": false,
  "createdAt": "ISO-8601",
  "updatedAt": "ISO-8601"
}
```

Validation failures return explicit `4xx` JSON responses in the shape `{ "error": "..." }`.

## File layout
```text
demo/todo-app/
  server.py
  data/
    .gitignore
  public/
    .gitkeep
  tests/
    test_server.py
```

## Storage notes
- runtime data lives in `demo/todo-app/data/todos.json`
- if the file is missing, the first API read/write bootstraps it as an empty list
- every mutation rewrites the file through a temporary sibling file and `os.replace(...)` for atomic persistence on the local filesystem

## Handoff notes
- **Frontend:** the server serves `/` and other static files from `demo/todo-app/public/`, so the existing UI PR can drop assets there without needing another process or route shim
- **QA:** use `python -m unittest discover -s demo/todo-app/tests -v` for backend-focused validation once the branch is checked out

Closes #40