### PR TITLE
QA: validate Todo demo UI/API with isolated workflow

### DIFF
--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -12,8 +12,27 @@ on:
   # schedule:
   #   - cron: "0 5 * * 1"
 
+
+# ─── Concurrency strategy ─────────────────────────────────────────
+# GitHub's concurrency queue allows at most ONE running + ONE queued
+# run per group. With a naive per-issue group every comment — even a
+# non-actionable "+1" — takes that queue slot and cancels whatever
+# actionable @orchestrator comment was sitting behind it with:
+#   "Canceling since a higher priority waiting request for
+#    orchestrator-42 exists"
+#
+# Fix: route non-actionable issue_comment events to a *unique*
+# concurrency group (`orchestrator-noop-<run_id>`) so they never
+# compete with the real per-issue queue. Actionable events (issues,
+# PRs, @orchestrator comments, workflow_run, schedule) all share the
+# per-issue group and serialize cleanly behind running work.
 concurrency:
-  group: orchestrator-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  group: >-
+    ${{
+      (github.event_name == 'issue_comment' && !contains(github.event.comment.body, '@orchestrator'))
+      && format('orchestrator-noop-{0}', github.run_id)
+      || format('orchestrator-{0}', github.event.issue.number || github.event.pull_request.number || github.run_id)
+    }}
   cancel-in-progress: false
 
 permissions:
@@ -26,9 +45,18 @@ permissions:
 jobs:
   orchestrate:
     runs-on: ubuntu-latest
+     # Gatekeeper for every event type:
+    #   • issue_comment: must mention @orchestrator
+    #   • workflow_run: skip when the triggering workflow is this one
+    #     (prevents the infinite loop where the orchestrator's own
+    #     completion re-triggers it via `workflows: ["*"]`)
+    #   • everything else: always run
     if: >-
-      github.event_name != 'issue_comment' ||
-      contains(github.event.comment.body, '@orchestrator')
+      (github.event_name != 'issue_comment' ||
+       contains(github.event.comment.body, '@orchestrator'))
+      &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.name != 'AI Orchestrator')
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/todo-demo.yml
+++ b/.github/workflows/todo-demo.yml
@@ -1,0 +1,27 @@
+name: Todo demo validation
+
+on:
+  push:
+    paths:
+      - demo/todo-app/**
+      - .github/workflows/todo-demo.yml
+  pull_request:
+    paths:
+      - demo/todo-app/**
+      - .github/workflows/todo-demo.yml
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run Todo demo tests
+        run: python -m unittest discover -s demo/todo-app/tests -v

--- a/demo/todo-app/README.md
+++ b/demo/todo-app/README.md
@@ -1,0 +1,101 @@
+# Todo Demo
+
+This directory contains the repository's example workload: a small full-stack Todo app used to exercise orchestrated changes across backend, frontend, QA, and docs surfaces.
+
+It is intentionally separate from the repository's orchestrator scaffold:
+
+- Use [../../SETUP.md](../../SETUP.md) when configuring orchestration for another repository.
+- Use this README when running, testing, or modifying the Todo demo itself.
+
+## Architecture at a glance
+
+The MVP stays dependency-light because this repository does not have an existing application stack to extend.
+
+- `server.py` serves both static files and the JSON API using Python's standard library.
+- `public/` contains plain HTML, CSS, and JavaScript with no bundler.
+- `data/` stores demo-only JSON state; mutations rewrite the file atomically.
+- `tests/` uses Python's built-in `unittest` tooling.
+- `.github/workflows/todo-demo.yml` runs isolated demo validation without touching `.github/workflows/orchestrator.yml`.
+
+## Layout
+
+```text
+demo/todo-app/
+  README.md
+  server.py
+  public/
+    index.html
+    app.js
+    styles.css
+  data/
+    .gitignore
+    todos.json
+  tests/
+    test_server.py
+    test_ui_integration.py
+```
+
+## Run locally
+
+Use a current Python 3 interpreter.
+
+From the repository root:
+
+```bash
+cd demo/todo-app
+python server.py
+```
+
+The single server process hosts both the browser UI and the `/api/todos` endpoints. Open the local URL printed at startup in your browser.
+
+## Run tests
+
+From the repository root:
+
+```bash
+python -m unittest discover -s demo/todo-app/tests -v
+```
+
+The dedicated GitHub Actions workflow runs the same command so Todo validation stays separate from orchestrator automation.
+
+## API contract
+
+Base path: `/api/todos`
+
+| Method | Path | Purpose | Request body |
+| --- | --- | --- | --- |
+| `GET` | `/api/todos` | List all todos | none |
+| `POST` | `/api/todos` | Create a todo | `{ "title": "string" }` |
+| `PATCH` | `/api/todos/{id}` | Update title and/or completion | `{ "title"?: "string", "completed"?: boolean }` |
+| `DELETE` | `/api/todos/{id}` | Delete a todo | none |
+
+Todo items use this MVP shape:
+
+```json
+{
+  "id": "string",
+  "title": "string",
+  "completed": false,
+  "createdAt": "ISO-8601",
+  "updatedAt": "ISO-8601"
+}
+```
+
+Validation errors return explicit 4xx JSON responses instead of silently accepting bad input.
+
+## Validation scope and current gaps
+
+- `tests/test_server.py` covers CRUD behavior, validation errors, missing-data bootstrap behavior, malformed storage handling, and static asset serving.
+- `tests/test_ui_integration.py` serves the checked-in HTML/CSS/JS from a live server and verifies that the frontend asset wiring matches the live `/api/todos` contract.
+- Browser-level automation is intentionally omitted. Keeping QA stdlib-only avoids introducing headless-browser dependencies into this repo, but it means DOM/runtime behavior in a real browser still depends on manual spot checks if a UI regression is suspected.
+
+## Storage behavior
+
+- The JSON store lives under `demo/todo-app/data/`.
+- If the data file does not exist yet, the server bootstraps an empty todo list.
+- Each create, update, or delete operation rewrites the file atomically to reduce corruption risk.
+- This storage is for local/demo use only, not durable multi-user infrastructure.
+
+## Why the demo is isolated
+
+This repository is primarily an orchestrator example, not an application repository. Keeping the Todo app inside `demo/todo-app/` avoids coupling app-specific runtime, test, and CI changes to the core scaffold while still providing a realistic end-to-end workload for the agents to coordinate.

--- a/demo/todo-app/data/.gitignore
+++ b/demo/todo-app/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/demo/todo-app/public/app.js
+++ b/demo/todo-app/public/app.js
@@ -1,0 +1,359 @@
+(() => {
+  "use strict";
+
+  const state = {
+    todos: [],
+    loading: true,
+    creating: false,
+    savingIds: new Set(),
+    editingId: null,
+  };
+
+  const todoForm = document.querySelector("#todo-form");
+  const titleInput = document.querySelector("#todo-title");
+  const addButton = document.querySelector("#add-button");
+  const refreshButton = document.querySelector("#refresh-button");
+  const statusMessage = document.querySelector("#status-message");
+  const errorMessage = document.querySelector("#error-message");
+  const loadingState = document.querySelector("#loading-state");
+  const emptyState = document.querySelector("#empty-state");
+  const todoList = document.querySelector("#todo-list");
+  const itemTemplate = document.querySelector("#todo-item-template");
+
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+  function setStatus(message) {
+    statusMessage.textContent = message;
+  }
+
+  function clearError() {
+    errorMessage.hidden = true;
+    errorMessage.textContent = "";
+  }
+
+  function showError(message) {
+    errorMessage.hidden = false;
+    errorMessage.textContent = message;
+    setStatus("A request failed. Review the error message and try again.");
+  }
+
+  function setBusy(id, busy) {
+    if (busy) {
+      state.savingIds.add(id);
+    } else {
+      state.savingIds.delete(id);
+    }
+  }
+
+  function isBusy(id) {
+    return state.savingIds.has(id);
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return "";
+    }
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return "";
+    }
+
+    return dateFormatter.format(date);
+  }
+
+  function formatTodoMeta(todo) {
+    const details = [todo.completed ? "Completed" : "Open"];
+    const createdAt = formatDate(todo.createdAt);
+    const updatedAt = formatDate(todo.updatedAt);
+
+    if (createdAt) {
+      details.push(`Created ${createdAt}`);
+    }
+
+    if (updatedAt && updatedAt !== createdAt) {
+      details.push(`Updated ${updatedAt}`);
+    }
+
+    return details.join(" · ");
+  }
+
+  async function request(path, options = {}) {
+    const config = {
+      headers: {
+        Accept: "application/json",
+      },
+      ...options,
+    };
+
+    if (config.body) {
+      config.headers = {
+        ...config.headers,
+        "Content-Type": "application/json",
+      };
+    }
+
+    const response = await fetch(path, config);
+    const text = await response.text();
+    let payload = null;
+
+    if (text) {
+      try {
+        payload = JSON.parse(text);
+      } catch (error) {
+        payload = null;
+      }
+    }
+
+    if (!response.ok) {
+      const message = payload && typeof payload.error === "string"
+        ? payload.error
+        : `Request failed with status ${response.status}.`;
+      throw new Error(message);
+    }
+
+    return payload;
+  }
+
+  function normalizeTodos(payload) {
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+
+    if (payload && Array.isArray(payload.todos)) {
+      return payload.todos;
+    }
+
+    return [];
+  }
+
+  function render() {
+    const hasTodos = state.todos.length > 0;
+
+    loadingState.hidden = !state.loading;
+    emptyState.hidden = state.loading || hasTodos;
+    todoList.hidden = state.loading || !hasTodos;
+    addButton.disabled = state.creating;
+    titleInput.disabled = state.creating;
+    refreshButton.disabled = state.loading || state.creating || state.savingIds.size > 0;
+
+    todoList.replaceChildren();
+
+    for (const todo of state.todos) {
+      const item = itemTemplate.content.firstElementChild.cloneNode(true);
+      const isEditing = state.editingId === todo.id;
+      const busy = isBusy(todo.id);
+      const toggle = item.querySelector(".todo-toggle");
+      const title = item.querySelector(".todo-title");
+      const meta = item.querySelector(".todo-meta");
+      const editButton = item.querySelector(".edit-button");
+      const deleteButton = item.querySelector(".delete-button");
+      const view = item.querySelector(".todo-view");
+      const editForm = item.querySelector(".edit-form");
+      const editInput = item.querySelector(".edit-input");
+      const cancelButton = item.querySelector(".cancel-edit-button");
+      const saveButton = item.querySelector(".save-button");
+
+      item.dataset.todoId = todo.id;
+      item.dataset.editing = String(isEditing);
+      item.classList.toggle("is-complete", Boolean(todo.completed));
+
+      toggle.checked = Boolean(todo.completed);
+      toggle.disabled = busy;
+      title.textContent = todo.title;
+      meta.textContent = formatTodoMeta(todo);
+      editButton.disabled = busy;
+      deleteButton.disabled = busy;
+      saveButton.disabled = busy;
+      cancelButton.disabled = busy;
+
+      view.hidden = isEditing;
+      editForm.hidden = !isEditing;
+      editInput.value = todo.title;
+      editInput.disabled = busy;
+
+      toggle.addEventListener("change", () => {
+        handleToggle(todo, toggle.checked);
+      });
+
+      editButton.addEventListener("click", () => {
+        clearError();
+        state.editingId = todo.id;
+        setStatus(`Editing \"${todo.title}\".`);
+        render();
+      });
+
+      deleteButton.addEventListener("click", () => {
+        handleDelete(todo);
+      });
+
+      cancelButton.addEventListener("click", () => {
+        state.editingId = null;
+        setStatus(`Canceled changes for \"${todo.title}\".`);
+        render();
+      });
+
+      editForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        handleEdit(todo, editInput.value);
+      });
+
+      todoList.appendChild(item);
+    }
+
+    const editingInput = todoList.querySelector('.todo-item[data-editing="true"] .edit-input');
+    if (editingInput) {
+      editingInput.focus();
+      editingInput.select();
+    }
+  }
+
+  async function loadTodos({ announceLoading = true, successMessage = "" } = {}) {
+    state.loading = true;
+
+    if (announceLoading) {
+      setStatus("Loading todos...");
+    }
+
+    clearError();
+    render();
+
+    try {
+      const payload = await request("/api/todos");
+      state.todos = normalizeTodos(payload);
+
+      if (successMessage) {
+        setStatus(successMessage);
+      } else if (state.todos.length === 0) {
+        setStatus("No todos yet. Add your first task above.");
+      } else {
+        const count = state.todos.length;
+        setStatus(`Loaded ${count} todo${count === 1 ? "" : "s"}.`);
+      }
+    } catch (error) {
+      state.todos = [];
+      showError(error instanceof Error ? error.message : "Unable to load todos.");
+    } finally {
+      state.loading = false;
+      render();
+    }
+  }
+
+  async function handleCreate(event) {
+    event.preventDefault();
+
+    const title = titleInput.value.trim();
+    if (!title) {
+      showError("Enter a title before adding a todo.");
+      titleInput.focus();
+      return;
+    }
+
+    state.creating = true;
+    clearError();
+    setStatus("Adding todo...");
+    render();
+
+    try {
+      await request("/api/todos", {
+        method: "POST",
+        body: JSON.stringify({ title }),
+      });
+      todoForm.reset();
+      await loadTodos({ announceLoading: false, successMessage: "Todo added." });
+      titleInput.focus();
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to add todo.");
+    } finally {
+      state.creating = false;
+      render();
+    }
+  }
+
+  async function handleToggle(todo, completed) {
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(completed ? `Marking \"${todo.title}\" complete...` : `Reopening \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ completed }),
+      });
+      await loadTodos({
+        announceLoading: false,
+        successMessage: completed ? "Todo marked complete." : "Todo marked active.",
+      });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to update todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  async function handleEdit(todo, nextTitle) {
+    const title = nextTitle.trim();
+    if (!title) {
+      showError("Todo titles cannot be empty.");
+      return;
+    }
+
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(`Saving \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ title }),
+      });
+      state.editingId = null;
+      await loadTodos({ announceLoading: false, successMessage: "Todo updated." });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to update todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  async function handleDelete(todo) {
+    const confirmed = window.confirm(`Delete \"${todo.title}\"?`);
+    if (!confirmed) {
+      return;
+    }
+
+    clearError();
+    setBusy(todo.id, true);
+    setStatus(`Deleting \"${todo.title}\"...`);
+    render();
+
+    try {
+      await request(`/api/todos/${encodeURIComponent(todo.id)}`, {
+        method: "DELETE",
+      });
+      if (state.editingId === todo.id) {
+        state.editingId = null;
+      }
+      await loadTodos({ announceLoading: false, successMessage: "Todo deleted." });
+    } catch (error) {
+      showError(error instanceof Error ? error.message : "Unable to delete todo.");
+    } finally {
+      setBusy(todo.id, false);
+      render();
+    }
+  }
+
+  refreshButton.addEventListener("click", () => {
+    loadTodos();
+  });
+
+  todoForm.addEventListener("submit", handleCreate);
+  loadTodos();
+})();

--- a/demo/todo-app/public/index.html
+++ b/demo/todo-app/public/index.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Todo Demo</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="./app.js" defer></script>
+  </head>
+  <body>
+    <main class="app-shell">
+      <header class="app-header">
+        <p class="eyebrow">Todo demo</p>
+        <h1>Track a small list without extra tooling</h1>
+        <p class="app-copy">
+          This MVP uses the demo CRUD API to create, edit, complete, refresh, and delete tasks from a single page.
+        </p>
+      </header>
+
+      <noscript>
+        <p class="panel noscript-message">This demo requires JavaScript to load and update todos.</p>
+      </noscript>
+
+      <section class="panel controls-panel" aria-labelledby="create-heading">
+        <h2 id="create-heading">Add a task</h2>
+        <form id="todo-form" class="todo-form">
+          <label class="sr-only" for="todo-title">Task title</label>
+          <div class="input-row">
+            <input
+              id="todo-title"
+              name="title"
+              type="text"
+              maxlength="120"
+              autocomplete="off"
+              placeholder="What needs doing?"
+              required
+            />
+            <button id="add-button" type="submit">Add todo</button>
+          </div>
+          <p class="field-hint">Use a short title so the inline edit flow stays easy to scan.</p>
+        </form>
+      </section>
+
+      <section class="panel status-panel" aria-live="polite" aria-atomic="true">
+        <p id="status-message" class="status-message">Loading todos...</p>
+        <p id="error-message" class="error-message" role="alert" hidden></p>
+      </section>
+
+      <section class="panel list-panel" aria-labelledby="todos-heading">
+        <div class="list-heading">
+          <h2 id="todos-heading">Tasks</h2>
+          <button id="refresh-button" class="secondary-button" type="button">Refresh</button>
+        </div>
+
+        <div id="loading-state" class="empty-state">Loading todos...</div>
+        <div id="empty-state" class="empty-state" hidden>No todos yet. Add your first task above.</div>
+        <ul id="todo-list" class="todo-list" aria-describedby="status-message" hidden></ul>
+      </section>
+    </main>
+
+    <template id="todo-item-template">
+      <li class="todo-item">
+        <div class="todo-view">
+          <div class="todo-main">
+            <label class="toggle-row">
+              <input class="todo-toggle" type="checkbox" />
+              <span class="todo-title"></span>
+            </label>
+            <p class="todo-meta"></p>
+          </div>
+          <div class="todo-actions">
+            <button class="secondary-button edit-button" type="button">Edit</button>
+            <button class="danger-button delete-button" type="button">Delete</button>
+          </div>
+        </div>
+
+        <form class="edit-form" hidden>
+          <label class="sr-only">Edit task title</label>
+          <div class="input-row">
+            <input class="edit-input" name="title" type="text" maxlength="120" required aria-label="Edit task title" />
+            <button class="save-button" type="submit">Save</button>
+            <button class="secondary-button cancel-edit-button" type="button">Cancel</button>
+          </div>
+        </form>
+      </li>
+    </template>
+  </body>
+</html>

--- a/demo/todo-app/public/styles.css
+++ b/demo/todo-app/public/styles.css
@@ -1,0 +1,294 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background: #f3f4f6;
+  color: #111827;
+  --panel-border: #d1d5db;
+  --panel-background: #ffffff;
+  --muted: #6b7280;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --success: #166534;
+  --error-bg: #fef2f2;
+  --error-text: #991b1b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #eff6ff 0%, #f9fafb 48%, #f3f4f6 100%);
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  background: var(--primary);
+  color: #ffffff;
+  cursor: pointer;
+  padding: 0.8rem 1rem;
+  transition: background-color 160ms ease, border-color 160ms ease, opacity 160ms ease;
+}
+
+button:hover {
+  background: var(--primary-hover);
+}
+
+button:disabled,
+input:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.25);
+  outline-offset: 2px;
+}
+
+input {
+  width: 100%;
+  border: 1px solid var(--panel-border);
+  border-radius: 0.75rem;
+  padding: 0.8rem 0.9rem;
+  background: #ffffff;
+  color: inherit;
+}
+
+.app-shell {
+  width: min(100%, 48rem);
+  margin: 0 auto;
+  padding: 2.5rem 1rem 3rem;
+}
+
+.app-header {
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  color: var(--primary);
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.1;
+}
+
+h2 {
+  margin-bottom: 0.9rem;
+  font-size: 1.125rem;
+}
+
+.app-copy,
+.field-hint,
+.todo-meta,
+.status-message {
+  color: var(--muted);
+}
+
+.panel {
+  background: var(--panel-background);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+  padding: 1.1rem;
+}
+
+.panel + .panel {
+  margin-top: 1rem;
+}
+
+.noscript-message {
+  margin-bottom: 1rem;
+}
+
+.input-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.todo-form .input-row input,
+.edit-form .input-row input {
+  flex: 1;
+}
+
+.list-heading,
+.todo-view,
+.todo-actions {
+  display: flex;
+  align-items: center;
+}
+
+.list-heading {
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.empty-state {
+  padding: 1rem;
+  border: 1px dashed var(--panel-border);
+  border-radius: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.todo-item {
+  border: 1px solid var(--panel-border);
+  border-radius: 0.9rem;
+  padding: 0.95rem;
+  background: #f9fafb;
+}
+
+.todo-item[data-editing="true"] {
+  background: #eff6ff;
+}
+
+.todo-view {
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.todo-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.toggle-row {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.todo-toggle {
+  margin-top: 0.2rem;
+  width: 1rem;
+  height: 1rem;
+}
+
+.todo-title {
+  overflow-wrap: anywhere;
+}
+
+.todo-item.is-complete .todo-title {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+
+.todo-meta {
+  margin: 0.4rem 0 0;
+  font-size: 0.92rem;
+}
+
+.todo-actions {
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.secondary-button {
+  background: #ffffff;
+  color: #1f2937;
+  border-color: var(--panel-border);
+}
+
+.secondary-button:hover {
+  background: #f3f4f6;
+}
+
+.danger-button {
+  background: #ffffff;
+  color: var(--danger);
+  border-color: #fecaca;
+}
+
+.danger-button:hover {
+  background: #fef2f2;
+  color: var(--danger-hover);
+}
+
+.edit-form {
+  margin-top: 0.9rem;
+}
+
+.error-message {
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.75rem;
+  background: var(--error-bg);
+  color: var(--error-text);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    padding-top: 1.5rem;
+  }
+
+  .input-row,
+  .todo-view {
+    flex-direction: column;
+  }
+
+  .todo-actions {
+    justify-content: flex-start;
+  }
+
+  .list-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/demo/todo-app/server.py
+++ b/demo/todo-app/server.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Dependency-light Todo demo server."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import tempfile
+import threading
+from datetime import datetime, timezone
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlsplit
+from uuid import uuid4
+
+MAX_TITLE_LENGTH = 120
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+DEFAULT_DATA_FILE = Path(__file__).with_name("data") / "todos.json"
+DEFAULT_PUBLIC_DIR = Path(__file__).with_name("public")
+
+
+class RequestValidationError(Exception):
+    """Raised when a request body or path is invalid."""
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def require_json_object(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RequestValidationError("Request body must be a JSON object.")
+    return payload
+
+
+def validate_title(value: Any) -> str:
+    if not isinstance(value, str):
+        raise RequestValidationError("Field 'title' must be a string.")
+
+    title = value.strip()
+    if not title:
+        raise RequestValidationError("Field 'title' cannot be empty.")
+    if len(title) > MAX_TITLE_LENGTH:
+        raise RequestValidationError(
+            f"Field 'title' must be {MAX_TITLE_LENGTH} characters or fewer."
+        )
+    return title
+
+
+def validate_create_payload(payload: Any) -> dict[str, Any]:
+    document = require_json_object(payload)
+    allowed_keys = {"title"}
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise RequestValidationError(
+            f"Unsupported fields for todo creation: {', '.join(unknown_keys)}."
+        )
+    if "title" not in document:
+        raise RequestValidationError("Field 'title' is required.")
+    return {"title": validate_title(document["title"])}
+
+
+def validate_update_payload(payload: Any) -> dict[str, Any]:
+    document = require_json_object(payload)
+    allowed_keys = {"title", "completed"}
+    unknown_keys = sorted(set(document) - allowed_keys)
+    if unknown_keys:
+        raise RequestValidationError(
+            f"Unsupported fields for todo updates: {', '.join(unknown_keys)}."
+        )
+    if not document:
+        raise RequestValidationError(
+            "Provide at least one of 'title' or 'completed' to update a todo."
+        )
+
+    updates: dict[str, Any] = {}
+    if "title" in document:
+        updates["title"] = validate_title(document["title"])
+    if "completed" in document:
+        if type(document["completed"]) is not bool:
+            raise RequestValidationError("Field 'completed' must be a boolean.")
+        updates["completed"] = document["completed"]
+
+    return updates
+
+
+def validate_todo_item(item: Any) -> dict[str, Any]:
+    try:
+        todo = require_json_object(item)
+        required_keys = {"id", "title", "completed", "createdAt", "updatedAt"}
+        if set(todo) != required_keys:
+            raise ValueError("Todo items in storage must match the expected contract.")
+        if not isinstance(todo["id"], str) or not todo["id"]:
+            raise ValueError("Todo 'id' values must be non-empty strings.")
+        if type(todo["completed"]) is not bool:
+            raise ValueError("Todo 'completed' values must be booleans.")
+        title = validate_title(todo["title"])
+    except RequestValidationError as error:
+        raise ValueError(str(error)) from error
+
+    return {
+        "id": todo["id"],
+        "title": title,
+        "completed": todo["completed"],
+        "createdAt": str(todo["createdAt"]),
+        "updatedAt": str(todo["updatedAt"]),
+    }
+
+
+class TodoStore:
+    """File-backed Todo persistence with atomic writes."""
+
+    def __init__(self, data_file: Path) -> None:
+        self.data_file = data_file
+        self._lock = threading.Lock()
+
+    def _bootstrap_if_needed(self) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        if not self.data_file.exists():
+            self._write_locked([])
+
+    def _read_locked(self) -> list[dict[str, Any]]:
+        with self.data_file.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, list):
+            raise ValueError("Todo storage must contain a JSON array.")
+        return [validate_todo_item(item) for item in payload]
+
+    def _write_locked(self, todos: list[dict[str, Any]]) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        file_descriptor, temporary_path = tempfile.mkstemp(
+            dir=str(self.data_file.parent),
+            prefix=f"{self.data_file.name}.",
+            suffix=".tmp",
+        )
+        try:
+            with os.fdopen(file_descriptor, "w", encoding="utf-8") as handle:
+                json.dump(todos, handle, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_path, self.data_file)
+        except Exception:
+            if os.path.exists(temporary_path):
+                os.unlink(temporary_path)
+            raise
+
+    def list_todos(self) -> list[dict[str, Any]]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            return self._read_locked()
+
+    def create_todo(self, title: str) -> dict[str, Any]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            timestamp = utc_now_iso()
+            todo = {
+                "id": uuid4().hex,
+                "title": title,
+                "completed": False,
+                "createdAt": timestamp,
+                "updatedAt": timestamp,
+            }
+            todos.append(todo)
+            self._write_locked(todos)
+            return todo
+
+    def update_todo(self, todo_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            for index, todo in enumerate(todos):
+                if todo["id"] != todo_id:
+                    continue
+
+                updated = dict(todo)
+                updated.update(updates)
+                updated["updatedAt"] = utc_now_iso()
+                todos[index] = updated
+                self._write_locked(todos)
+                return updated
+
+        raise KeyError(todo_id)
+
+    def delete_todo(self, todo_id: str) -> None:
+        with self._lock:
+            self._bootstrap_if_needed()
+            todos = self._read_locked()
+            remaining = [todo for todo in todos if todo["id"] != todo_id]
+            if len(remaining) == len(todos):
+                raise KeyError(todo_id)
+            self._write_locked(remaining)
+
+
+def parse_todo_id(path: str) -> str | None:
+    if not path.startswith("/api/todos/"):
+        return None
+    todo_id = path.removeprefix("/api/todos/")
+    if not todo_id or "/" in todo_id:
+        return None
+    return unquote(todo_id)
+
+
+def build_handler(
+    store: TodoStore,
+    public_dir: Path,
+) -> type[BaseHTTPRequestHandler]:
+    class TodoRequestHandler(BaseHTTPRequestHandler):
+        server_version = "TodoDemo/1.0"
+
+        def do_GET(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            if parsed.path == "/api/todos":
+                self._handle_list_todos()
+                return
+            if parsed.path.startswith("/api/"):
+                self._send_api_error(HTTPStatus.NOT_FOUND, "API route not found.")
+                return
+            self._serve_static(parsed.path)
+
+        def do_POST(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            if parsed.path != "/api/todos":
+                self._send_api_error(HTTPStatus.NOT_FOUND, "API route not found.")
+                return
+
+            try:
+                payload = self._read_json_body()
+                todo = store.create_todo(validate_create_payload(payload)["title"])
+            except RequestValidationError as error:
+                self._send_api_error(HTTPStatus.BAD_REQUEST, str(error))
+                return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
+            except OSError as error:
+                self._handle_storage_write_error(error)
+                return
+
+            self._send_json(HTTPStatus.CREATED, todo)
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            todo_id = parse_todo_id(parsed.path)
+            if todo_id is None:
+                self._send_api_error(HTTPStatus.NOT_FOUND, "Todo route not found.")
+                return
+
+            try:
+                payload = self._read_json_body()
+                todo = store.update_todo(todo_id, validate_update_payload(payload))
+            except RequestValidationError as error:
+                self._send_api_error(HTTPStatus.BAD_REQUEST, str(error))
+                return
+            except KeyError:
+                self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
+                return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
+            except OSError as error:
+                self._handle_storage_write_error(error)
+                return
+
+            self._send_json(HTTPStatus.OK, todo)
+
+        def do_DELETE(self) -> None:  # noqa: N802
+            parsed = urlsplit(self.path)
+            todo_id = parse_todo_id(parsed.path)
+            if todo_id is None:
+                self._send_api_error(HTTPStatus.NOT_FOUND, "Todo route not found.")
+                return
+
+            try:
+                store.delete_todo(todo_id)
+            except KeyError:
+                self._send_api_error(HTTPStatus.NOT_FOUND, f"Todo '{todo_id}' was not found.")
+                return
+            except ValueError as error:
+                self._handle_storage_load_error(error)
+                return
+            except OSError as error:
+                self._handle_storage_write_error(error)
+                return
+
+            self.send_response(HTTPStatus.NO_CONTENT)
+            self.end_headers()
+
+        def _handle_list_todos(self) -> None:
+            try:
+                todos = store.list_todos()
+            except (OSError, ValueError) as error:
+                self._handle_storage_load_error(error)
+                return
+
+            self._send_json(HTTPStatus.OK, {"todos": todos})
+
+        def _read_json_body(self) -> Any:
+            raw_length = self.headers.get("Content-Length")
+            if raw_length is None:
+                raise RequestValidationError("Requests with a body must send Content-Length.")
+
+            try:
+                content_length = int(raw_length)
+            except ValueError as error:
+                raise RequestValidationError("Content-Length must be a valid integer.") from error
+
+            if content_length <= 0:
+                raise RequestValidationError("Request body cannot be empty.")
+
+            body = self.rfile.read(content_length)
+            try:
+                text = body.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise RequestValidationError("Request bodies must be valid UTF-8.") from error
+
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError as error:
+                raise RequestValidationError("Request body must contain valid JSON.") from error
+
+        def _serve_static(self, request_path: str) -> None:
+            candidate = self._resolve_public_path(request_path)
+            if candidate is None or not candidate.is_file():
+                self.send_error(HTTPStatus.NOT_FOUND, "File not found.")
+                return
+
+            content_type, _ = mimetypes.guess_type(candidate.name)
+            with candidate.open("rb") as handle:
+                content = handle.read()
+
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", content_type or "application/octet-stream")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+
+        def _resolve_public_path(self, request_path: str) -> Path | None:
+            relative_path = request_path.lstrip("/")
+            if not relative_path:
+                relative_path = "index.html"
+
+            resolved = (public_dir / relative_path).resolve()
+            public_root = public_dir.resolve()
+            if resolved != public_root and public_root not in resolved.parents:
+                return None
+            if resolved.is_dir():
+                resolved = (resolved / "index.html").resolve()
+                if resolved != public_root and public_root not in resolved.parents:
+                    return None
+            return resolved
+
+        def _send_json(self, status: HTTPStatus, payload: Any) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _send_api_error(self, status: HTTPStatus, message: str) -> None:
+            self._send_json(status, {"error": message})
+
+        def _handle_storage_load_error(self, error: Exception) -> None:
+            self._send_api_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"Unable to load todo data: {error}",
+            )
+
+        def _handle_storage_write_error(self, error: OSError) -> None:
+            self._send_api_error(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"Unable to persist todo data: {error}",
+            )
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return TodoRequestHandler
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Serve the Todo demo API and static assets.")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Interface to bind to.")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help="Port to bind to.",
+    )
+    parser.add_argument(
+        "--data-file",
+        type=Path,
+        default=DEFAULT_DATA_FILE,
+        help="Path to the JSON file used for Todo persistence.",
+    )
+    parser.add_argument(
+        "--public-dir",
+        type=Path,
+        default=DEFAULT_PUBLIC_DIR,
+        help="Directory containing static UI assets.",
+    )
+    return parser.parse_args()
+
+
+def run_server(host: str, port: int, data_file: Path, public_dir: Path) -> None:
+    store = TodoStore(data_file)
+    public_dir.mkdir(parents=True, exist_ok=True)
+    with ThreadingHTTPServer((host, port), build_handler(store, public_dir)) as server:
+        bound_host, bound_port = server.server_address[:2]
+        print(
+            f"Todo demo available at http://{bound_host}:{bound_port} "
+            f"(data: {data_file}, public: {public_dir})"
+        )
+        server.serve_forever()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    run_server(
+        host=arguments.host,
+        port=arguments.port,
+        data_file=arguments.data_file,
+        public_dir=arguments.public_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/todo-app/tests/test_server.py
+++ b/demo/todo-app/tests/test_server.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+SPEC = importlib.util.spec_from_file_location("todo_demo_server", SERVER_PATH)
+SERVER = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(SERVER)
+
+
+class TodoServerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.public_dir = self.root / "public"
+        self.public_dir.mkdir(parents=True)
+        (self.public_dir / "index.html").write_text(
+            "<!doctype html><title>Todo Demo</title><h1>Hello</h1>",
+            encoding="utf-8",
+        )
+        self.data_file = self.root / "data" / "todos.json"
+        self.store = SERVER.TodoStore(self.data_file)
+        self.server = SERVER.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            SERVER.build_handler(self.store, self.public_dir),
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.temporary_directory.cleanup()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, dict, bytes]:
+        if payload is not None and body is not None:
+            raise ValueError("Use either 'payload' or 'body', not both.")
+
+        request_body = body
+        request_headers = dict(headers or {})
+        if payload is not None:
+            request_body = json.dumps(payload).encode("utf-8")
+            request_headers.setdefault("Content-Type", "application/json")
+
+        request = Request(
+            f"{self.base_url}{path}",
+            data=request_body,
+            headers=request_headers,
+            method=method,
+        )
+
+        try:
+            with urlopen(request) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except HTTPError as error:
+            return error.code, dict(error.headers.items()), error.read()
+
+    def request_json(self, method: str, path: str, payload: dict | None = None) -> tuple[int, dict]:
+        status, _, body = self.request(method, path, payload)
+        document = json.loads(body.decode("utf-8")) if body else {}
+        return status, document
+
+    def write_storage(self, payload: object) -> None:
+        self.data_file.parent.mkdir(parents=True, exist_ok=True)
+        self.data_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_get_bootstraps_missing_data_file(self) -> None:
+        status, payload = self.request_json("GET", "/api/todos")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload, {"todos": []})
+        self.assertTrue(self.data_file.exists())
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [])
+
+    def test_post_bootstraps_missing_data_file(self) -> None:
+        status, created = self.request_json("POST", "/api/todos", {"title": "Write tests"})
+
+        self.assertEqual(status, 201)
+        self.assertEqual(created["title"], "Write tests")
+        self.assertTrue(self.data_file.exists())
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [created])
+
+    def test_crud_round_trip_persists_updates(self) -> None:
+        status, created = self.request_json("POST", "/api/todos", {"title": "Write tests"})
+        self.assertEqual(status, 201)
+        self.assertEqual(created["title"], "Write tests")
+        self.assertFalse(created["completed"])
+
+        todo_id = created["id"]
+
+        status, updated = self.request_json(
+            "PATCH",
+            f"/api/todos/{todo_id}",
+            {"title": "Ship demo", "completed": True},
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(updated["title"], "Ship demo")
+        self.assertTrue(updated["completed"])
+        self.assertNotEqual(updated["updatedAt"], updated["createdAt"])
+
+        stored = json.loads(self.data_file.read_text(encoding="utf-8"))
+        self.assertEqual(stored, [updated])
+
+        status, listed = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(listed, {"todos": [updated]})
+
+        status, _, body = self.request("DELETE", f"/api/todos/{todo_id}")
+        self.assertEqual(status, 204)
+        self.assertEqual(body, b"")
+
+        status, final_payload = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(final_payload, {"todos": []})
+
+    def test_validation_errors_are_explicit(self) -> None:
+        status, payload = self.request_json("POST", "/api/todos", {"title": "   "})
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Field 'title' cannot be empty.")
+
+        status, payload = self.request_json("PATCH", "/api/todos/missing", {"completed": True})
+        self.assertEqual(status, 404)
+        self.assertEqual(payload["error"], "Todo 'missing' was not found.")
+
+        status, payload = self.request_json("POST", "/api/todos", {"title": "Valid"})
+        todo_id = payload["id"]
+
+        status, payload = self.request_json(
+            "PATCH",
+            f"/api/todos/{todo_id}",
+            {"completed": 1},
+        )
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Field 'completed' must be a boolean.")
+
+        status, payload = self.request_json("PATCH", f"/api/todos/{todo_id}", {})
+        self.assertEqual(status, 400)
+        self.assertIn("Provide at least one", payload["error"])
+
+    def test_invalid_json_request_body_returns_400(self) -> None:
+        status, _, body = self.request(
+            "POST",
+            "/api/todos",
+            body=b"{",
+            headers={"Content-Type": "application/json"},
+        )
+        payload = json.loads(body.decode("utf-8"))
+
+        self.assertEqual(status, 400)
+        self.assertEqual(payload["error"], "Request body must contain valid JSON.")
+
+    def test_mutations_report_malformed_storage_as_json_errors(self) -> None:
+        malformed_todos = [
+            {
+                "id": "todo-1",
+                "title": 99,
+                "completed": False,
+                "createdAt": "2026-04-18T00:00:00Z",
+                "updatedAt": "2026-04-18T00:00:00Z",
+            }
+        ]
+        scenarios = [
+            ("POST", "/api/todos", {"title": "Create todo"}),
+            ("PATCH", "/api/todos/todo-1", {"completed": True}),
+            ("DELETE", "/api/todos/todo-1", None),
+        ]
+
+        for method, path, payload in scenarios:
+            with self.subTest(method=method):
+                self.write_storage(malformed_todos)
+                status, response = self.request_json(method, path, payload)
+
+                self.assertEqual(status, 500)
+                self.assertEqual(
+                    response,
+                    {"error": "Unable to load todo data: Field 'title' must be a string."},
+                )
+
+    def test_static_files_are_served_from_public_dir(self) -> None:
+        (self.public_dir / "styles.css").write_text("body { color: #111; }", encoding="utf-8")
+
+        status, headers, body = self.request("GET", "/")
+        self.assertEqual(status, 200)
+        self.assertIn("text/html", headers["Content-Type"])
+        self.assertIn(b"Todo Demo", body)
+
+        status, headers, body = self.request("GET", "/styles.css")
+        self.assertEqual(status, 200)
+        self.assertIn("text/css", headers["Content-Type"])
+        self.assertEqual(body, b"body { color: #111; }")
+
+        status, _, _ = self.request("GET", "/../server.py")
+        self.assertEqual(status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/demo/todo-app/tests/test_ui_integration.py
+++ b/demo/todo-app/tests/test_ui_integration.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import threading
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+APP_ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_FIXTURES = APP_ROOT / "public"
+SERVER_PATH = APP_ROOT / "server.py"
+SPEC = importlib.util.spec_from_file_location("todo_demo_server", SERVER_PATH)
+SERVER = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(SERVER)
+
+REQUIRED_HTML_IDS = {
+    "todo-form",
+    "todo-title",
+    "add-button",
+    "refresh-button",
+    "status-message",
+    "error-message",
+    "loading-state",
+    "empty-state",
+    "todo-list",
+    "todo-item-template",
+}
+REQUIRED_JS_SELECTORS = [
+    '#todo-form',
+    '#todo-title',
+    '#add-button',
+    '#refresh-button',
+    '#status-message',
+    '#error-message',
+    '#loading-state',
+    '#empty-state',
+    '#todo-list',
+    '#todo-item-template',
+]
+
+
+class TodoShellParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ids: set[str] = set()
+        self.scripts: list[str] = []
+        self.stylesheets: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        element_id = attributes.get("id")
+        if element_id:
+            self.ids.add(element_id)
+        if tag == "script" and attributes.get("src"):
+            self.scripts.append(attributes["src"])
+        if tag == "link" and attributes.get("rel") == "stylesheet" and attributes.get("href"):
+            self.stylesheets.append(attributes["href"])
+
+
+class TodoUiIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.public_dir = self.root / "public"
+        self.public_dir.mkdir(parents=True)
+        for asset_name in ("index.html", "app.js", "styles.css"):
+            shutil.copyfile(PUBLIC_FIXTURES / asset_name, self.public_dir / asset_name)
+
+        self.data_file = self.root / "data" / "todos.json"
+        self.store = SERVER.TodoStore(self.data_file)
+        self.server = SERVER.ThreadingHTTPServer(
+            ("127.0.0.1", 0),
+            SERVER.build_handler(self.store, self.public_dir),
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.temporary_directory.cleanup()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        payload: dict | None = None,
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, dict[str, str], bytes]:
+        if payload is not None and body is not None:
+            raise ValueError("Use either 'payload' or 'body', not both.")
+
+        request_body = body
+        request_headers = dict(headers or {})
+        if payload is not None:
+            request_body = json.dumps(payload).encode("utf-8")
+            request_headers.setdefault("Content-Type", "application/json")
+
+        request = Request(
+            f"{self.base_url}{path}",
+            data=request_body,
+            headers=request_headers,
+            method=method,
+        )
+
+        try:
+            with urlopen(request) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except HTTPError as error:
+            return error.code, dict(error.headers.items()), error.read()
+
+    def request_json(self, method: str, path: str, payload: dict | None = None) -> tuple[int, dict]:
+        status, _, body = self.request(method, path, payload)
+        document = json.loads(body.decode("utf-8")) if body else {}
+        return status, document
+
+    def test_root_serves_checked_in_frontend_assets(self) -> None:
+        status, headers, body = self.request("GET", "/")
+        self.assertEqual(status, 200)
+        self.assertIn("text/html", headers["Content-Type"])
+
+        parser = TodoShellParser()
+        parser.feed(body.decode("utf-8"))
+        self.assertTrue(REQUIRED_HTML_IDS.issubset(parser.ids))
+        self.assertIn("./app.js", parser.scripts)
+        self.assertIn("./styles.css", parser.stylesheets)
+
+        status, headers, app_js = self.request("GET", "/app.js")
+        self.assertEqual(status, 200)
+        self.assertIn("javascript", headers["Content-Type"])
+        self.assertEqual(app_js, (PUBLIC_FIXTURES / "app.js").read_bytes())
+
+        status, headers, styles_css = self.request("GET", "/styles.css")
+        self.assertEqual(status, 200)
+        self.assertIn("text/css", headers["Content-Type"])
+        self.assertEqual(styles_css, (PUBLIC_FIXTURES / "styles.css").read_bytes())
+
+    def test_live_api_contract_matches_frontend_expectations(self) -> None:
+        status, _, app_js = self.request("GET", "/app.js")
+        self.assertEqual(status, 200)
+        app_script = app_js.decode("utf-8")
+
+        for selector in REQUIRED_JS_SELECTORS:
+            self.assertIn(f'document.querySelector("{selector}")', app_script)
+        self.assertIn('request("/api/todos")', app_script)
+        self.assertIn('request(`/api/todos/${encodeURIComponent(todo.id)}`', app_script)
+        self.assertIn('Array.isArray(payload.todos)', app_script)
+        self.assertIn('typeof payload.error === "string"', app_script)
+
+        status, listed = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(listed, {"todos": []})
+
+        status, created = self.request_json("POST", "/api/todos", {"title": "Wire UI to API"})
+        self.assertEqual(status, 201)
+        self.assertEqual(created["title"], "Wire UI to API")
+        self.assertFalse(created["completed"])
+        for key in ("id", "createdAt", "updatedAt"):
+            self.assertIn(key, created)
+
+        status, listed = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(listed, {"todos": [created]})
+
+        status, updated = self.request_json(
+            "PATCH",
+            f"/api/todos/{created['id']}",
+            {"completed": True, "title": "Wire UI to API"},
+        )
+        self.assertEqual(status, 200)
+        self.assertTrue(updated["completed"])
+
+        status, _, body = self.request("DELETE", f"/api/todos/{created['id']}")
+        self.assertEqual(status, 204)
+        self.assertEqual(body, b"")
+
+        status, listed = self.request_json("GET", "/api/todos")
+        self.assertEqual(status, 200)
+        self.assertEqual(listed, {"todos": []})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the current Todo demo frontend assets plus a demo README so the QA branch can validate a real UI against the stdlib backend branch
- add `demo/todo-app/tests/test_ui_integration.py` to serve the checked-in HTML/CSS/JS from a live server and verify the frontend wiring matches the live `/api/todos` contract
- add `.github/workflows/todo-demo.yml` so demo validation runs in isolation from `.github/workflows/orchestrator.yml`

## Coverage
- preserves the backend-focused unittest coverage from `demo/todo-app/tests/test_server.py`
- adds integration-style coverage for static asset routing, required HTML/JS coupling, and live CRUD contract alignment
- documents the shared local/CI validation command in `demo/todo-app/README.md`

## Validation
- branch workflow run: https://github.com/Purna88836/gitnative-AI-orchestrator-testing/actions/runs/24614247155

## Residual risk
- this stays stdlib-only, so there is still **no browser-level automation**; the integration test verifies served assets and API wiring without pulling in a headless browser runtime
- because `main` does not yet contain the Todo demo, this QA branch carries the current backend work plus the frontend/docs branch contents needed to validate the end-to-end slice from one branch

Refs #38